### PR TITLE
fix: React StrictMode 제거로 지도 컴포넌트 이중 렌더링 방지

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,12 +1,7 @@
-import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App.jsx'
 import './styles/theme.css'
 import './styles/tailwind.css'
 import './styles/index.css'
 
-createRoot(document.getElementById('root')).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-)
+createRoot(document.getElementById('root')).render(<App />)


### PR DESCRIPTION
## 📌 개요
StrictMode로 인해 지도 컴포넌트(Kakao Maps)가 두 번 초기화되는 문제를 수정합니다.

## 🔍 변경 사유
React StrictMode는 개발 환경에서 useEffect를 두 번 실행하여 Kakao Maps 인스턴스가 중복 생성됩니다.

## 🛠 작업 내용
- `main.jsx`에서 `<StrictMode>` 제거

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)