### PR TITLE
feat: 커뮤니티 게시글 목록에 댓글 수 표시

### DIFF
--- a/src/pages/community/PostListPage.jsx
+++ b/src/pages/community/PostListPage.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router';
 import axios from '../../api/axios';
 import { Button } from '../../components/ui/button';
-import { Plus, Heart } from 'lucide-react';
+import { Plus, Heart, MessageCircle } from 'lucide-react';
 
 export default function PostListPage() {
   const [posts, setPosts] = useState([]);
@@ -34,9 +34,15 @@ export default function PostListPage() {
           >
             <div className="flex justify-between items-start mb-2">
               <h3 className="text-xl font-bold text-gray-800">{post.title}</h3>
-              <div className="flex items-center gap-1 text-purple-600">
-                <Heart className="w-5 h-5" />
-                <span className="font-semibold">{post.likeCount}</span>
+              <div className="flex items-center gap-3">
+                <div className="flex items-center gap-1 text-purple-600">
+                  <Heart className="w-4 h-4" />
+                  <span className="text-sm font-semibold">{post.likeCount}</span>
+                </div>
+                <div className="flex items-center gap-1 text-gray-400">
+                  <MessageCircle className="w-4 h-4" />
+                  <span className="text-sm">{post.commentCount ?? 0}</span>
+                </div>
               </div>
             </div>
             <p className="text-sm text-gray-500">


### PR DESCRIPTION
## 📌 개요
게시글 리스트에서 좋아요 수 옆에 댓글 수도 표시합니다.

## 🔍 변경 사유
현재 좋아요 수만 표시되어 게시글의 활성도를 파악하기 어렵습니다.

## 🛠 작업 내용
- `PostListPage.jsx`: MessageCircle 아이콘 + `commentCount` 표시 추가

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)