### PR TITLE
fix: 게시글 상세 진입 시 좋아요 상태 서버에서 초기화

### DIFF
--- a/src/pages/community/PostDetailPage.jsx
+++ b/src/pages/community/PostDetailPage.jsx
@@ -18,6 +18,7 @@ export default function PostDetailPage() {
     axios.get(`/api/posts/${postId}`).then((res) => {
       setPost(res.data);
       setLikeCount(res.data.likeCount);
+      setLiked(res.data.liked ?? false);
     });
     axios.get(`/api/posts/${postId}/comments`).then((res) => setComments(res.data));
   }, [postId]);


### PR DESCRIPTION
## 📌 개요
페이지 재진입 시 좋아요(하트) 상태가 항상 false로 초기화되는 버그를 수정합니다.

## 🔍 변경 사유
`useEffect`에서 `likeCount`만 서버에서 받아오고 `liked` 여부는 초기화하지 않아 하트 상태가 유지되지 않았습니다.

## 🛠 작업 내용
- `PostDetailPage.jsx`: `setLiked(res.data.liked ?? false)` 추가

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)