### PR TITLE
fix: 펫 나이 음수 입력 방지

### DIFF
--- a/src/pages/pet/PetPage.jsx
+++ b/src/pages/pet/PetPage.jsx
@@ -115,6 +115,7 @@ export default function PetPage() {
                   id="age"
                   name="age"
                   type="number"
+                  min="0"
                   placeholder="나이"
                   value={form.age}
                   onChange={handleChange}


### PR DESCRIPTION
## 📌 개요
펫 등록 시 나이에 음수가 입력되지 않도록 제한합니다.

## 🛠 작업 내용
- `PetPage.jsx` 나이 input에 `min="0"` 속성 추가

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)