### PR TITLE
feat: 카카오 지도 전환, 채팅/병원/산책 UX 개선, 에러 모달, 마이페이지

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,146 @@
+# PawPaw Frontend — 개발 컨텍스트
+
+## 프로젝트 개요
+반려동물 커뮤니티 앱. React + Vite + TailwindCSS + shadcn/ui 기반.  
+백엔드: Spring Boot (localhost:8080), WebSocket(STOMP+SockJS) 채팅.
+
+---
+
+## 기술 스택
+
+| 항목 | 사용 기술 |
+|------|-----------|
+| 프레임워크 | React 18 (StrictMode 제거 — Kakao Maps 이중 초기화 방지) |
+| 라우팅 | react-router v7 (`createBrowserRouter`) |
+| 상태관리 | Zustand (`authStore`, `errorStore`) |
+| 지도 | Kakao Maps SDK (`libraries=services`) |
+| 채팅 | @stomp/stompjs + SockJS |
+| HTTP | Axios (인터셉터로 토큰 자동 첨부 + 리프레시 처리) |
+| UI | shadcn/ui (Radix UI 기반) + lucide-react |
+
+---
+
+## 주요 파일 구조
+
+```
+src/
+├── api/axios.js          # axios 인스턴스 + 인터셉터 (토큰 갱신, 에러 처리)
+├── store/
+│   ├── authStore.js      # isLoggedIn, userId
+│   └── errorStore.js     # networkError, sessionExpired (전역 에러 상태)
+├── App.jsx               # RouterProvider + SessionExpiredModal + NetworkErrorModal
+├── routes.jsx            # 라우트 정의 (PrivateRoute 포함)
+├── components/Layout.jsx # 헤더 + 네비게이션 바
+└── pages/
+    ├── auth/             # LoginPage, SignUpPage
+    ├── community/        # PostListPage, PostDetailPage, PostCreatePage
+    ├── chat/             # ChatPage
+    ├── hospital/         # HospitalPage
+    ├── walk/             # WalkRequestPage
+    ├── pet/              # PetPage
+    └── mypage/           # MyPage
+```
+
+---
+
+## 2026-04-23 작업 내용 (PR #27, feat/session-expired-modal)
+
+### 🗺 지도 API 전환 (Naver → Kakao)
+- `index.html` 스크립트를 Kakao Maps SDK로 교체
+- `HospitalPage`, `WalkRequestPage` 모두 `window.kakao.maps` 기반으로 재구현
+- 역지오코딩: `coord2Address(lng, lat, cb)` — **경도 먼저**
+- 지역명 변환: `coord2RegionCode(lng, lat, cb)`
+- 키워드 검색: `kakao.maps.services.Places().keywordSearch()`
+
+### 💬 채팅 개선
+- **한국어 IME 중복 전송 방지**: `onKeyDown`에 `!e.nativeEvent.isComposing` 조건 추가
+- **레이아웃**: `grid(반응형)` → `flex(고정)` — 항상 목록(288px) + 채팅창 가로 배치
+- **상대방 이름 표시**: `room.requesterId === userId`면 `receiverNickname`, 아니면 `requesterNickname`
+- **채팅방 생성 실패 메시지**: "채팅방 생성 실패" → "이미 채팅방이 만들어져 있습니다."
+
+### 🏥 동물병원 개선
+- **GPS 자동 검색**: 진입 시 `navigator.geolocation` → `coord2RegionCode` → 지역명 → 병원 자동 검색
+- **네비바**: "동물병원" → "가까운 동물병원"
+- **전화 버튼**: 전화번호 텍스트 → `tel:` 링크 전화하기 버튼
+- **재방문 리뷰 뱃지**: 같은 닉네임이 같은 병원에 2번째 이상 리뷰 시 "두번째 리뷰" 뱃지 표시
+- **별점 UI**: 5개 인터랙티브 Star 컴포넌트 (readonly/interactive 모드)
+- **6개 이상 리뷰**: `max-h-[400px] overflow-y-auto` 스크롤
+
+### 🚶 산책 매칭 개선
+- **알바비 자동 포맷**: 숫자만 입력하면 `10,000원` 형태로 자동 변환
+- **날짜/시간 유효성**:
+  - 날짜: `min={TODAY}` (오늘 이전 선택 불가)
+  - 시작 시간: 오늘 선택 시 현재 시각 이전 불가
+  - 종료 시간: 시작 시간 이전 불가, 시작 시간 선택 시 자동 +1분
+- **위치 선택 지도 개선**:
+  - 키워드 검색 → 결과 드롭다운 목록 표시 (장소명 + 주소)
+  - 목록 클릭 또는 지도 직접 클릭으로 위치 선택
+  - "선택 완료" 버튼으로 위치 확정
+
+### ❤️ 커뮤니티 좋아요 상태 유지
+- `localStorage.setItem('liked_{userId}_{postId}', 'true/false')`로 저장
+- 페이지 재진입 시 localStorage 우선 읽기 → 서버 `liked` 필드 fallback
+
+### 🧑 마이페이지 신규 구현 (`src/pages/mypage/MyPage.jsx`)
+- 프로필: 이니셜 아바타, 닉네임, 이메일, 주소, 가입일
+- 프로필 수정 모달: 닉네임·주소 편집, GPS 버튼으로 현재 위치 자동 입력
+- 활동 통계: 작성 글 수, 산책 매칭 수
+- 탭: 작성한 글 목록 / 산책 매칭 목록
+
+**필요한 API 응답 필드:**
+- `GET /api/users/me` → `{ nickname, email, address, createdAt }`
+- `GET /api/posts/my` → `[{ id, title, category, createdAt }]`
+- `GET /api/walk-requests/my` → `[{ id, title, walkDate, startTime, endTime, location, reward }]`
+- `PUT /api/users/me` → `{ nickname, address }` 전송, 수정된 유저 반환
+
+### 🚨 에러 처리 (서버 연결 끊김 / 세션 만료)
+- **errorStore** (Zustand): `networkError`, `sessionExpired` 전역 상태
+- **axios 인터셉터**:
+  - `!error.response` → `setNetworkError(true)` (서버 다운)
+  - 401 리프레시 실패 → `setSessionExpired(true)`
+- **App.jsx**:
+  - `SessionExpiredModal`: 강제 모달 (닫기 불가), 다시 로그인 버튼
+  - `NetworkErrorModal`: 닫기 또는 다시 로그인 선택 가능
+
+---
+
+## 주의사항 / 알려진 제약
+
+- **StrictMode 제거됨** — `src/main.jsx`에서 제거. Kakao Maps useEffect 이중 실행 방지 목적
+- **Kakao Maps 도메인 등록 필요** — Kakao Developers 콘솔에서 `http://localhost:5173` 등록해야 지도 타일 표시
+- **채팅 requesterId/receiverId** — 채팅방 API 응답에 두 필드가 있어야 상대방 이름 정확히 표시
+- **마이페이지 `/api/walk-requests/my`** — 내가 등록한 산책 매칭만 반환하는 전용 엔드포인트 필요
+- **좋아요 상태** — 서버가 `liked` 필드를 응답에 포함하면 localStorage 대신 서버 값 우선 사용 가능
+
+---
+
+## 브랜치 / PR 현황 (2026-04-23 기준)
+
+| 브랜치 | PR | 내용 |
+|--------|----|------|
+| feat/session-expired-modal | #27 | 이 문서의 모든 변경사항 |
+| feat/hospital-improvements | #? | 동물병원 별점/리뷰 초기 구현 |
+| feat/walk-improvements | #? | 산책 매칭 초기 개선 |
+| feat/mypage | #? | 마이페이지 초기 구현 |
+| feat/post-image-upload | #? | 게시글 이미지 업로드 |
+| feat/community-comment-count | #? | 댓글 개수 표시 |
+| fix/like-state-sync | #? | 좋아요 상태 동기화 |
+
+---
+
+## 이슈 번호 참조
+
+| # | 내용 | 상태 |
+|---|------|------|
+| 28 | Naver → Kakao 지도 전환 | PR #27에서 처리 |
+| 29 | 서버 연결/세션 만료 모달 | PR #27에서 처리 |
+| 30 | 채팅 IME 중복 전송 | PR #27에서 처리 |
+| 31 | 동물병원 GPS/전화 버튼/재방문 리뷰 | PR #27에서 처리 |
+| 32 | 산책 매칭 지도 검색 결과 목록 | PR #27에서 처리 |
+| 4  | 좋아요 상태 초기화 버그 | PR #27에서 처리 |
+| 6  | 채팅방 상대방 이름 표시 | PR #27에서 처리 |
+| 7  | 채팅방 생성 실패 메시지 | PR #27에서 처리 |
+| 11 | 마이페이지 구현 | PR #27에서 처리 |
+| 12 | 산책 날짜/시간 유효성 | PR #27에서 처리 |
+| 13 | 알바비 포맷 | PR #27에서 처리 |
+| 15 | 동물병원 GPS 자동 검색 | PR #27에서 처리 |

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>pawpaw-frontend</title>
-    <script type="text/javascript" src="https://oapi.map.naver.com/openapi/v3/maps.js?ncpKeyId=92txrtc7m0&submodules=geocoder"></script>
+    <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=3d04b3a0e6ecb8420fffc5995f0ff8c3&libraries=services"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,6 @@ if (typeof window !== 'undefined') {
   window.global = window;
 }
 
-import { useEffect } from "react";
 import { RouterProvider } from "react-router";
 import { router } from "./routes";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "./components/ui/dialog";
@@ -10,7 +9,6 @@ import { Button } from "./components/ui/button";
 import { LogIn, WifiOff } from "lucide-react";
 import useAuthStore from "./store/authStore";
 import useErrorStore from "./store/errorStore";
-import axios from "./api/axios";
 
 function SessionExpiredModal() {
   const sessionExpired = useErrorStore((s) => s.sessionExpired);
@@ -103,22 +101,10 @@ function NetworkErrorModal() {
   );
 }
 
-function AuthValidator() {
-  const isLoggedIn = useAuthStore((s) => s.isLoggedIn);
-
-  useEffect(() => {
-    if (!isLoggedIn) return;
-    axios.get('/api/users/me').catch(() => {});
-  }, [isLoggedIn]);
-
-  return null;
-}
-
 export default function App() {
   return (
     <>
       <RouterProvider router={router} />
-      <AuthValidator />
       <SessionExpiredModal />
       <NetworkErrorModal />
     </>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,32 +2,29 @@ if (typeof window !== 'undefined') {
   window.global = window;
 }
 
-import { useState, useEffect } from "react";
-import { RouterProvider, useNavigate } from "react-router";
+import { useEffect } from "react";
+import { RouterProvider } from "react-router";
 import { router } from "./routes";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "./components/ui/dialog";
 import { Button } from "./components/ui/button";
 import { LogIn, WifiOff } from "lucide-react";
 import useAuthStore from "./store/authStore";
+import useErrorStore from "./store/errorStore";
+import axios from "./api/axios";
 
 function SessionExpiredModal() {
-  const [open, setOpen] = useState(false);
-  const setLoggedIn = useAuthStore((state) => state.setLoggedIn);
-
-  useEffect(() => {
-    const handleSessionExpired = () => setOpen(true);
-    window.addEventListener('session-expired', handleSessionExpired);
-    return () => window.removeEventListener('session-expired', handleSessionExpired);
-  }, []);
+  const sessionExpired = useErrorStore((s) => s.sessionExpired);
+  const setSessionExpired = useErrorStore((s) => s.setSessionExpired);
+  const setLoggedIn = useAuthStore((s) => s.setLoggedIn);
 
   const handleReLogin = () => {
     setLoggedIn(false);
-    setOpen(false);
+    setSessionExpired(false);
     router.navigate('/login');
   };
 
   return (
-    <Dialog open={open}>
+    <Dialog open={sessionExpired}>
       <DialogContent
         className="max-w-sm text-center"
         onPointerDownOutside={(e) => e.preventDefault()}
@@ -59,25 +56,22 @@ function SessionExpiredModal() {
 }
 
 function NetworkErrorModal() {
-  const [open, setOpen] = useState(false);
-  const setLoggedIn = useAuthStore((state) => state.setLoggedIn);
+  const networkError = useErrorStore((s) => s.networkError);
+  const setNetworkError = useErrorStore((s) => s.setNetworkError);
+  const setLoggedIn = useAuthStore((s) => s.setLoggedIn);
 
-  useEffect(() => {
-    const handler = () => setOpen(true);
-    window.addEventListener('network-error', handler);
-    return () => window.removeEventListener('network-error', handler);
-  }, []);
+  const handleClose = () => setNetworkError(false);
 
   const handleReLogin = () => {
     setLoggedIn(false);
-    setOpen(false);
+    setNetworkError(false);
     localStorage.removeItem('accessToken');
     localStorage.removeItem('refreshToken');
     router.navigate('/login');
   };
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={networkError} onOpenChange={handleClose}>
       <DialogContent className="max-w-sm text-center">
         <DialogHeader>
           <DialogTitle className="text-xl font-bold text-gray-800">
@@ -85,25 +79,19 @@ function NetworkErrorModal() {
           </DialogTitle>
         </DialogHeader>
         <div className="py-2">
-          <div className="text-5xl mb-4">
-            <WifiOff className="w-14 h-14 mx-auto text-gray-400" />
-          </div>
+          <WifiOff className="w-14 h-14 mx-auto text-gray-400 mb-4" />
           <p className="text-gray-500 text-sm mb-6">
             서버 연결이 끊겼습니다.
             <br />
             잠시 후 다시 시도하거나 다시 로그인해주세요.
           </p>
           <div className="flex gap-2">
-            <Button
-              variant="outline"
-              onClick={() => setOpen(false)}
-              className="flex-1 border-gray-300 text-gray-600"
-            >
+            <Button variant="outline" onClick={handleClose} className="flex-1 border-gray-300 text-gray-600">
               닫기
             </Button>
             <Button
               onClick={handleReLogin}
-              className="flex-1 bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-700 hover:to-indigo-700 text-white shadow-md"
+              className="flex-1 bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-700 hover:to-indigo-700 text-white"
             >
               <LogIn className="w-4 h-4 mr-2" />
               다시 로그인
@@ -115,10 +103,22 @@ function NetworkErrorModal() {
   );
 }
 
+function AuthValidator() {
+  const isLoggedIn = useAuthStore((s) => s.isLoggedIn);
+
+  useEffect(() => {
+    if (!isLoggedIn) return;
+    axios.get('/api/users/me').catch(() => {});
+  }, [isLoggedIn]);
+
+  return null;
+}
+
 export default function App() {
   return (
     <>
       <RouterProvider router={router} />
+      <AuthValidator />
       <SessionExpiredModal />
       <NetworkErrorModal />
     </>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,7 +7,7 @@ import { RouterProvider, useNavigate } from "react-router";
 import { router } from "./routes";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "./components/ui/dialog";
 import { Button } from "./components/ui/button";
-import { LogIn } from "lucide-react";
+import { LogIn, WifiOff } from "lucide-react";
 import useAuthStore from "./store/authStore";
 
 function SessionExpiredModal() {
@@ -58,11 +58,69 @@ function SessionExpiredModal() {
   );
 }
 
+function NetworkErrorModal() {
+  const [open, setOpen] = useState(false);
+  const setLoggedIn = useAuthStore((state) => state.setLoggedIn);
+
+  useEffect(() => {
+    const handler = () => setOpen(true);
+    window.addEventListener('network-error', handler);
+    return () => window.removeEventListener('network-error', handler);
+  }, []);
+
+  const handleReLogin = () => {
+    setLoggedIn(false);
+    setOpen(false);
+    localStorage.removeItem('accessToken');
+    localStorage.removeItem('refreshToken');
+    router.navigate('/login');
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent className="max-w-sm text-center">
+        <DialogHeader>
+          <DialogTitle className="text-xl font-bold text-gray-800">
+            서버에 연결할 수 없습니다
+          </DialogTitle>
+        </DialogHeader>
+        <div className="py-2">
+          <div className="text-5xl mb-4">
+            <WifiOff className="w-14 h-14 mx-auto text-gray-400" />
+          </div>
+          <p className="text-gray-500 text-sm mb-6">
+            서버 연결이 끊겼습니다.
+            <br />
+            잠시 후 다시 시도하거나 다시 로그인해주세요.
+          </p>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              onClick={() => setOpen(false)}
+              className="flex-1 border-gray-300 text-gray-600"
+            >
+              닫기
+            </Button>
+            <Button
+              onClick={handleReLogin}
+              className="flex-1 bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-700 hover:to-indigo-700 text-white shadow-md"
+            >
+              <LogIn className="w-4 h-4 mr-2" />
+              다시 로그인
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 export default function App() {
   return (
     <>
       <RouterProvider router={router} />
       <SessionExpiredModal />
+      <NetworkErrorModal />
     </>
   );
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,9 +2,67 @@ if (typeof window !== 'undefined') {
   window.global = window;
 }
 
-import { RouterProvider } from "react-router";
+import { useState, useEffect } from "react";
+import { RouterProvider, useNavigate } from "react-router";
 import { router } from "./routes";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "./components/ui/dialog";
+import { Button } from "./components/ui/button";
+import { LogIn } from "lucide-react";
+import useAuthStore from "./store/authStore";
+
+function SessionExpiredModal() {
+  const [open, setOpen] = useState(false);
+  const setLoggedIn = useAuthStore((state) => state.setLoggedIn);
+
+  useEffect(() => {
+    const handleSessionExpired = () => setOpen(true);
+    window.addEventListener('session-expired', handleSessionExpired);
+    return () => window.removeEventListener('session-expired', handleSessionExpired);
+  }, []);
+
+  const handleReLogin = () => {
+    setLoggedIn(false);
+    setOpen(false);
+    router.navigate('/login');
+  };
+
+  return (
+    <Dialog open={open}>
+      <DialogContent
+        className="max-w-sm text-center"
+        onPointerDownOutside={(e) => e.preventDefault()}
+        onEscapeKeyDown={(e) => e.preventDefault()}
+      >
+        <DialogHeader>
+          <DialogTitle className="text-xl font-bold text-gray-800">
+            로그인이 만료되었습니다
+          </DialogTitle>
+        </DialogHeader>
+        <div className="py-2">
+          <div className="text-5xl mb-4">🔒</div>
+          <p className="text-gray-500 text-sm mb-6">
+            보안을 위해 세션이 만료되었습니다.
+            <br />
+            다시 로그인해주세요.
+          </p>
+          <Button
+            onClick={handleReLogin}
+            className="w-full bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-700 hover:to-indigo-700 text-white shadow-md hover:shadow-lg transition-all"
+          >
+            <LogIn className="w-4 h-4 mr-2" />
+            다시 로그인
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
 
 export default function App() {
-  return <RouterProvider router={router} />;
+  return (
+    <>
+      <RouterProvider router={router} />
+      <SessionExpiredModal />
+    </>
+  );
 }

--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import useErrorStore from '../store/errorStore';
 
 const instance = axios.create({
   baseURL: 'http://localhost:8080',
@@ -20,7 +21,7 @@ instance.interceptors.response.use(
   (response) => response,
   async (error) => {
     if (!error.response) {
-      window.dispatchEvent(new CustomEvent('network-error'));
+      useErrorStore.getState().setNetworkError(true);
       return Promise.reject(error);
     }
 
@@ -38,7 +39,7 @@ instance.interceptors.response.use(
       } catch (err) {
         localStorage.removeItem('accessToken');
         localStorage.removeItem('refreshToken');
-        window.dispatchEvent(new CustomEvent('session-expired'));
+        useErrorStore.getState().setSessionExpired(true);
         return Promise.reject(err);
       }
     }

--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -33,7 +33,7 @@ instance.interceptors.response.use(
       } catch (err) {
         localStorage.removeItem('accessToken');
         localStorage.removeItem('refreshToken');
-        window.location.href = '/login';
+        window.dispatchEvent(new CustomEvent('session-expired'));
         return Promise.reject(err);
       }
     }

--- a/src/api/axios.js
+++ b/src/api/axios.js
@@ -19,6 +19,11 @@ instance.interceptors.request.use(
 instance.interceptors.response.use(
   (response) => response,
   async (error) => {
+    if (!error.response) {
+      window.dispatchEvent(new CustomEvent('network-error'));
+      return Promise.reject(error);
+    }
+
     const originalRequest = error.config;
     if (error.response?.status === 401 && !originalRequest._retry) {
       originalRequest._retry = true;

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -17,7 +17,7 @@ export function Layout() {
   const navItems = [
     { icon: Home, label: "커뮤니티", path: "/" },
     { icon: Footprints, label: "산책 매칭", path: "/walk" },
-    { icon: Hospital, label: "동물병원", path: "/hospital" },
+    { icon: Hospital, label: "가까운 동물병원", path: "/hospital" },
     { icon: MessageCircle, label: "채팅", path: "/chat" },
     { icon: PawPrint, label: "내 펫", path: "/pets" },
     { icon: User, label: "마이페이지", path: "/mypage" },

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,16 +1,32 @@
+import { useState, useEffect } from "react";
 import { Outlet, Link, useLocation, useNavigate } from "react-router";
-import { Home, PawPrint, Footprints, Hospital, MessageCircle } from "lucide-react";
+import { Home, PawPrint, Footprints, Hospital, MessageCircle, LogIn } from "lucide-react";
 import useAuthStore from "../store/authStore";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "./ui/dialog";
+import { Button } from "./ui/button";
 
 export function Layout() {
   const location = useLocation();
   const navigate = useNavigate();
   const setLoggedIn = useAuthStore((state) => state.setLoggedIn);
+  const [sessionExpired, setSessionExpired] = useState(false);
+
+  useEffect(() => {
+    const handleSessionExpired = () => setSessionExpired(true);
+    window.addEventListener('session-expired', handleSessionExpired);
+    return () => window.removeEventListener('session-expired', handleSessionExpired);
+  }, []);
 
   const handleLogout = () => {
     localStorage.removeItem('accessToken');
     localStorage.removeItem('refreshToken');
     setLoggedIn(false);
+    navigate('/login');
+  };
+
+  const handleReLogin = () => {
+    setLoggedIn(false);
+    setSessionExpired(false);
     navigate('/login');
   };
 
@@ -24,6 +40,37 @@ export function Layout() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-purple-50 via-purple-50/50 to-indigo-50">
+
+      {/* 세션 만료 모달 */}
+      <Dialog open={sessionExpired}>
+        <DialogContent
+          className="max-w-sm text-center"
+          onPointerDownOutside={(e) => e.preventDefault()}
+          onEscapeKeyDown={(e) => e.preventDefault()}
+        >
+          <DialogHeader>
+            <DialogTitle className="text-xl font-bold text-gray-800">
+              로그인이 만료되었습니다
+            </DialogTitle>
+          </DialogHeader>
+          <div className="py-2">
+            <div className="text-5xl mb-4">🔒</div>
+            <p className="text-gray-500 text-sm mb-6">
+              보안을 위해 세션이 만료되었습니다.
+              <br />
+              다시 로그인해주세요.
+            </p>
+            <Button
+              onClick={handleReLogin}
+              className="w-full bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-700 hover:to-indigo-700 text-white shadow-md hover:shadow-lg transition-all"
+            >
+              <LogIn className="w-4 h-4 mr-2" />
+              다시 로그인
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
       {/* Header */}
       <header className="bg-white/80 backdrop-blur-sm border-b border-purple-100 sticky top-0 z-40">
         <div className="max-w-7xl mx-auto px-4 py-4 flex items-center justify-between">
@@ -33,7 +80,7 @@ export function Layout() {
               PawPaw
             </h1>
           </Link>
-          
+
           <button
             onClick={handleLogout}
             className="px-4 py-2 bg-gradient-to-r from-purple-600 to-indigo-600 text-white rounded-full hover:from-purple-700 hover:to-indigo-700 hover:shadow-lg transition-all"
@@ -50,7 +97,7 @@ export function Layout() {
             {navItems.map((item) => {
               const Icon = item.icon;
               const isActive = location.pathname === item.path;
-              
+
               return (
                 <Link
                   key={item.path}

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,21 +1,11 @@
-import { useState, useEffect } from "react";
 import { Outlet, Link, useLocation, useNavigate } from "react-router";
-import { Home, PawPrint, Footprints, Hospital, MessageCircle, LogIn } from "lucide-react";
+import { Home, Footprints, Hospital, MessageCircle, PawPrint, User } from "lucide-react";
 import useAuthStore from "../store/authStore";
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "./ui/dialog";
-import { Button } from "./ui/button";
 
 export function Layout() {
   const location = useLocation();
   const navigate = useNavigate();
   const setLoggedIn = useAuthStore((state) => state.setLoggedIn);
-  const [sessionExpired, setSessionExpired] = useState(false);
-
-  useEffect(() => {
-    const handleSessionExpired = () => setSessionExpired(true);
-    window.addEventListener('session-expired', handleSessionExpired);
-    return () => window.removeEventListener('session-expired', handleSessionExpired);
-  }, []);
 
   const handleLogout = () => {
     localStorage.removeItem('accessToken');
@@ -24,53 +14,17 @@ export function Layout() {
     navigate('/login');
   };
 
-  const handleReLogin = () => {
-    setLoggedIn(false);
-    setSessionExpired(false);
-    navigate('/login');
-  };
-
   const navItems = [
     { icon: Home, label: "커뮤니티", path: "/" },
-    { icon: PawPrint, label: "내 펫", path: "/pets" },
     { icon: Footprints, label: "산책 매칭", path: "/walk" },
     { icon: Hospital, label: "동물병원", path: "/hospital" },
     { icon: MessageCircle, label: "채팅", path: "/chat" },
+    { icon: PawPrint, label: "내 펫", path: "/pets" },
+    { icon: User, label: "마이페이지", path: "/mypage" },
   ];
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-purple-50 via-purple-50/50 to-indigo-50">
-
-      {/* 세션 만료 모달 */}
-      <Dialog open={sessionExpired}>
-        <DialogContent
-          className="max-w-sm text-center"
-          onPointerDownOutside={(e) => e.preventDefault()}
-          onEscapeKeyDown={(e) => e.preventDefault()}
-        >
-          <DialogHeader>
-            <DialogTitle className="text-xl font-bold text-gray-800">
-              로그인이 만료되었습니다
-            </DialogTitle>
-          </DialogHeader>
-          <div className="py-2">
-            <div className="text-5xl mb-4">🔒</div>
-            <p className="text-gray-500 text-sm mb-6">
-              보안을 위해 세션이 만료되었습니다.
-              <br />
-              다시 로그인해주세요.
-            </p>
-            <Button
-              onClick={handleReLogin}
-              className="w-full bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-700 hover:to-indigo-700 text-white shadow-md hover:shadow-lg transition-all"
-            >
-              <LogIn className="w-4 h-4 mr-2" />
-              다시 로그인
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
-
       {/* Header */}
       <header className="bg-white/80 backdrop-blur-sm border-b border-purple-100 sticky top-0 z-40">
         <div className="max-w-7xl mx-auto px-4 py-4 flex items-center justify-between">
@@ -103,6 +57,8 @@ export function Layout() {
                   key={item.path}
                   to={item.path}
                   className={`flex items-center gap-2 px-4 py-3 rounded-t-lg transition-all whitespace-nowrap ${
+                    item.path === '/pets' ? 'ml-auto' : ''
+                  } ${
                     isActive
                       ? "text-purple-600 border-b-2 border-purple-600 bg-purple-50"
                       : "text-gray-600 hover:text-purple-600 hover:bg-purple-50"

--- a/src/pages/chat/ChatPage.jsx
+++ b/src/pages/chat/ChatPage.jsx
@@ -73,22 +73,27 @@ export default function ChatPage() {
                 <p className="text-gray-600">아직 채팅방이 없어요</p>
               </div>
             )}
-            {chatRooms.map((room) => (
-              <button
-                key={room.id}
-                onClick={() => handleSelectRoom(room)}
-                className={`w-full p-4 flex items-center gap-3 hover:bg-purple-50 transition-colors border-b border-gray-50 text-left ${
-                  selectedRoom?.id === room.id ? 'bg-purple-50' : ''
-                }`}
-              >
-                <div className="text-3xl">🐾</div>
-                <div className="flex-1">
-                  <h3 className="font-semibold text-gray-800">
-                    {room.requesterNickname} - {room.receiverNickname}
-                  </h3>
-                </div>
-              </button>
-            ))}
+            {chatRooms.map((room) => {
+              const otherNickname = room.requesterId === userId
+                ? room.receiverNickname
+                : room.requesterNickname;
+              return (
+                <button
+                  key={room.id}
+                  onClick={() => handleSelectRoom(room)}
+                  className={`w-full p-4 flex items-center gap-3 hover:bg-purple-50 transition-colors border-b border-gray-50 text-left ${
+                    selectedRoom?.id === room.id ? 'bg-purple-50' : ''
+                  }`}
+                >
+                  <div className="w-11 h-11 rounded-full bg-gradient-to-br from-purple-400 to-indigo-400 flex items-center justify-center text-xl flex-shrink-0 shadow-sm">
+                    🐶
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <h3 className="font-semibold text-gray-800 truncate">{otherNickname}</h3>
+                  </div>
+                </button>
+              );
+            })}
           </div>
         </div>
 
@@ -97,9 +102,13 @@ export default function ChatPage() {
           <div className="lg:col-span-2 bg-white rounded-2xl shadow-sm flex flex-col overflow-hidden">
             {/* Chat Header */}
             <div className="p-4 border-b border-gray-100 flex items-center gap-3">
-              <div className="text-3xl">🐾</div>
+              <div className="w-10 h-10 rounded-full bg-gradient-to-br from-purple-400 to-indigo-400 flex items-center justify-center text-lg flex-shrink-0 shadow-sm">
+                🐶
+              </div>
               <h2 className="font-semibold text-gray-800">
-                {selectedRoom.requesterNickname} - {selectedRoom.receiverNickname}
+                {selectedRoom.requesterId === userId
+                  ? selectedRoom.receiverNickname
+                  : selectedRoom.requesterNickname}
               </h2>
             </div>
 

--- a/src/pages/chat/ChatPage.jsx
+++ b/src/pages/chat/ChatPage.jsx
@@ -19,6 +19,12 @@ export default function ChatPage() {
     axios.get('/api/chat/rooms').then((res) => setChatRooms(res.data));
   }, []);
 
+  const getOtherNickname = (room) => {
+    if (room.requesterId === userId) return room.receiverNickname;
+    if (room.receiverId === userId) return room.requesterNickname;
+    return room.receiverNickname;
+  };
+
   const connectWebSocket = (roomId) => {
     const token = localStorage.getItem('accessToken');
     const client = new Client({
@@ -27,9 +33,7 @@ export default function ChatPage() {
         Authorization: `Bearer ${token}`,
       },
       onConnect: () => {
-        console.log('WebSocket 연결됨');
         client.subscribe(`/sub/chat/room/${roomId}`, (message) => {
-          console.log('메시지 수신:', message.body);
           const received = JSON.parse(message.body);
           setMessages((prev) => [...prev, received]);
         });
@@ -60,55 +64,50 @@ export default function ChatPage() {
     <div className="max-w-7xl mx-auto">
       <h1 className="text-3xl font-bold text-gray-800 mb-6">채팅방</h1>
 
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 h-[calc(100vh-280px)]">
+      <div className="flex gap-6 h-[calc(100vh-280px)]">
         {/* Chat Room List */}
-        <div className="lg:col-span-1 bg-white rounded-2xl shadow-sm overflow-hidden">
+        <div className="w-72 flex-shrink-0 bg-white rounded-2xl shadow-sm overflow-hidden flex flex-col">
           <div className="p-4 border-b border-gray-100">
             <h2 className="font-semibold text-gray-800">대화 목록</h2>
           </div>
-          <div className="overflow-y-auto h-full">
+          <div className="overflow-y-auto flex-1">
             {chatRooms.length === 0 && (
               <div className="text-center py-12">
                 <div className="text-6xl mb-4">💬</div>
-                <p className="text-gray-600">아직 채팅방이 없어요</p>
+                <p className="text-gray-600 text-sm">아직 채팅방이 없어요</p>
               </div>
             )}
-            {chatRooms.map((room) => {
-              const otherNickname = room.requesterId === userId
-                ? room.receiverNickname
-                : room.requesterNickname;
-              return (
-                <button
-                  key={room.id}
-                  onClick={() => handleSelectRoom(room)}
-                  className={`w-full p-4 flex items-center gap-3 hover:bg-purple-50 transition-colors border-b border-gray-50 text-left ${
-                    selectedRoom?.id === room.id ? 'bg-purple-50' : ''
-                  }`}
-                >
-                  <div className="w-11 h-11 rounded-full bg-gradient-to-br from-purple-400 to-indigo-400 flex items-center justify-center text-xl flex-shrink-0 shadow-sm">
-                    🐶
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <h3 className="font-semibold text-gray-800 truncate">{otherNickname}</h3>
-                  </div>
-                </button>
-              );
-            })}
+            {chatRooms.map((room) => (
+              <button
+                key={room.id}
+                onClick={() => handleSelectRoom(room)}
+                className={`w-full p-4 flex items-center gap-3 hover:bg-purple-50 transition-colors border-b border-gray-50 text-left ${
+                  selectedRoom?.id === room.id ? 'bg-purple-50' : ''
+                }`}
+              >
+                <div className="w-11 h-11 rounded-full bg-gradient-to-br from-purple-400 to-indigo-400 flex items-center justify-center text-xl flex-shrink-0 shadow-sm">
+                  🐶
+                </div>
+                <div className="flex-1 min-w-0">
+                  <h3 className="font-semibold text-gray-800 truncate">
+                    {getOtherNickname(room)}
+                  </h3>
+                </div>
+              </button>
+            ))}
           </div>
         </div>
 
         {/* Chat Messages */}
         {selectedRoom ? (
-          <div className="lg:col-span-2 bg-white rounded-2xl shadow-sm flex flex-col overflow-hidden">
+          <div className="flex-1 bg-white rounded-2xl shadow-sm flex flex-col overflow-hidden min-w-0">
             {/* Chat Header */}
             <div className="p-4 border-b border-gray-100 flex items-center gap-3">
               <div className="w-10 h-10 rounded-full bg-gradient-to-br from-purple-400 to-indigo-400 flex items-center justify-center text-lg flex-shrink-0 shadow-sm">
                 🐶
               </div>
               <h2 className="font-semibold text-gray-800">
-                {selectedRoom.requesterId === userId
-                  ? selectedRoom.receiverNickname
-                  : selectedRoom.requesterNickname}
+                {getOtherNickname(selectedRoom)}
               </h2>
             </div>
 
@@ -141,11 +140,7 @@ export default function ChatPage() {
                           : 'bg-white shadow-sm'
                       }`}
                     >
-                      <p
-                        className={
-                          msg.senderId === userId ? 'text-white' : 'text-gray-800'
-                        }
-                      >
+                      <p className={msg.senderId === userId ? 'text-white' : 'text-gray-800'}>
                         {msg.content}
                       </p>
                     </div>
@@ -174,7 +169,7 @@ export default function ChatPage() {
             </div>
           </div>
         ) : (
-          <div className="lg:col-span-2 bg-white rounded-2xl shadow-sm flex items-center justify-center">
+          <div className="flex-1 bg-white rounded-2xl shadow-sm flex items-center justify-center min-w-0">
             <div className="text-center">
               <div className="text-6xl mb-4">💬</div>
               <p className="text-gray-600">채팅방을 선택해주세요</p>

--- a/src/pages/chat/ChatPage.jsx
+++ b/src/pages/chat/ChatPage.jsx
@@ -152,7 +152,7 @@ export default function ChatPage() {
                   placeholder="메시지 입력"
                   value={content}
                   onChange={(e) => setContent(e.target.value)}
-                  onKeyDown={(e) => e.key === 'Enter' && handleSend()}
+                  onKeyDown={(e) => e.key === 'Enter' && !e.nativeEvent.isComposing && handleSend()}
                   className="flex-1 rounded-full border-purple-200 focus:border-purple-400"
                 />
                 <Button

--- a/src/pages/community/PostDetailPage.jsx
+++ b/src/pages/community/PostDetailPage.jsx
@@ -18,6 +18,7 @@ export default function PostDetailPage() {
     axios.get(`/api/posts/${postId}`).then((res) => {
       setPost(res.data);
       setLikeCount(res.data.likeCount);
+      setLiked(res.data.liked ?? false);
     });
     axios.get(`/api/posts/${postId}/comments`).then((res) => setComments(res.data));
   }, [postId]);

--- a/src/pages/community/PostDetailPage.jsx
+++ b/src/pages/community/PostDetailPage.jsx
@@ -1,13 +1,17 @@
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router';
 import axios from '../../api/axios';
+import useAuthStore from '../../store/authStore';
 import { Button } from '../../components/ui/button';
 import { Input } from '../../components/ui/input';
 import { ArrowLeft, Heart, MessageCircle } from 'lucide-react';
 
+const getLikedKey = (userId, postId) => `liked_${userId}_${postId}`;
+
 export default function PostDetailPage() {
   const { postId } = useParams();
   const navigate = useNavigate();
+  const userId = useAuthStore((state) => state.userId);
   const [post, setPost] = useState(null);
   const [comments, setComments] = useState([]);
   const [content, setContent] = useState('');
@@ -18,19 +22,22 @@ export default function PostDetailPage() {
     axios.get(`/api/posts/${postId}`).then((res) => {
       setPost(res.data);
       setLikeCount(res.data.likeCount);
-      setLiked(res.data.liked ?? false);
+      const stored = localStorage.getItem(getLikedKey(userId, postId));
+      setLiked(stored !== null ? stored === 'true' : (res.data.liked ?? false));
     });
     axios.get(`/api/posts/${postId}/comments`).then((res) => setComments(res.data));
-  }, [postId]);
+  }, [postId, userId]);
 
   const handleLike = async () => {
     const res = await axios.post(`/api/posts/${postId}/likes`);
     if (res.data === '좋아요') {
       setLikeCount((prev) => prev + 1);
       setLiked(true);
+      localStorage.setItem(getLikedKey(userId, postId), 'true');
     } else {
       setLikeCount((prev) => prev - 1);
       setLiked(false);
+      localStorage.setItem(getLikedKey(userId, postId), 'false');
     }
   };
 

--- a/src/pages/hospital/HospitalPage.jsx
+++ b/src/pages/hospital/HospitalPage.jsx
@@ -236,16 +236,14 @@ export default function HospitalPage() {
                       {h.address}
                     </div>
                     {h.phone && (
-                      <div className="flex items-center gap-2">
-                        <Phone className="w-4 h-4 text-purple-600 shrink-0" />
-                        <a
-                          href={`tel:${h.phone}`}
-                          onClick={(e) => e.stopPropagation()}
-                          className="text-purple-600 hover:underline"
-                        >
-                          {h.phone}
-                        </a>
-                      </div>
+                      <a
+                        href={`tel:${h.phone}`}
+                        onClick={(e) => e.stopPropagation()}
+                        className="inline-flex items-center gap-1.5 mt-1 px-3 py-1.5 bg-purple-50 text-purple-600 text-sm font-medium rounded-full hover:bg-purple-100 transition-colors"
+                      >
+                        <Phone className="w-3.5 h-3.5" />
+                        전화하기
+                      </a>
                     )}
                   </div>
                 </div>

--- a/src/pages/hospital/HospitalPage.jsx
+++ b/src/pages/hospital/HospitalPage.jsx
@@ -3,221 +3,284 @@ import axios from '../../api/axios';
 import { Button } from '../../components/ui/button';
 import { Input } from '../../components/ui/input';
 import { Label } from '../../components/ui/label';
-import { MapPin, Star, Phone } from 'lucide-react';
+import { MapPin, Star, Phone, Loader2 } from 'lucide-react';
+
+function StarRating({ value, onChange, readonly = false, size = 'md' }) {
+  const [hovered, setHovered] = useState(0);
+  const sz = size === 'sm' ? 'w-4 h-4' : 'w-6 h-6';
+  return (
+    <div className="flex gap-0.5">
+      {[1, 2, 3, 4, 5].map((star) => (
+        <Star
+          key={star}
+          className={`${sz} cursor-${readonly ? 'default' : 'pointer'} transition-colors ${
+            star <= (hovered || value)
+              ? 'fill-yellow-400 text-yellow-400'
+              : 'text-gray-300'
+          }`}
+          onMouseEnter={() => !readonly && setHovered(star)}
+          onMouseLeave={() => !readonly && setHovered(0)}
+          onClick={() => !readonly && onChange?.(star)}
+        />
+      ))}
+    </div>
+  );
+}
 
 export default function HospitalPage() {
   const [query, setQuery] = useState('');
   const [hospitals, setHospitals] = useState([]);
-  const [reviews, setReviews] = useState([]);
+  const [reviews, setReviews] = useState({});
   const [selectedHospital, setSelectedHospital] = useState(null);
-  const [reviewForm, setReviewForm] = useState({ rating: '', content: '' });
+  const [reviewForm, setReviewForm] = useState({ rating: 0, content: '' });
+  const [gpsLoading, setGpsLoading] = useState(false);
   const mapRef = useRef(null);
   const mapInstanceRef = useRef(null);
   const markersRef = useRef([]);
 
   useEffect(() => {
-    if (typeof window.naver === 'undefined') return;
-    
-    // 지도 초기화
-    const map = new window.naver.maps.Map(mapRef.current, {
-      center: new window.naver.maps.LatLng(37.5665, 126.9780),
-      zoom: 13,
-    });
-    mapInstanceRef.current = map;
+    const initMap = (lat = 37.5665, lng = 126.9780) => {
+      if (typeof window.kakao === 'undefined' || !mapRef.current) return null;
+      const kakao = window.kakao;
+      const map = new kakao.maps.Map(mapRef.current, {
+        center: new kakao.maps.LatLng(lat, lng),
+        level: 5,
+      });
+      mapInstanceRef.current = map;
+      return map;
+    };
+
+    const map = initMap();
+    if (!map) return;
+
+    if (!navigator.geolocation) return;
+
+    setGpsLoading(true);
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        const { latitude: lat, longitude: lng } = pos.coords;
+        const kakao = window.kakao;
+        const userLatLng = new kakao.maps.LatLng(lat, lng);
+        map.setCenter(userLatLng);
+        map.setLevel(4);
+
+        const geocoder = new kakao.maps.services.Geocoder();
+        geocoder.coord2RegionCode(lng, lat, (result, status) => {
+          setGpsLoading(false);
+          if (status === kakao.maps.services.Status.OK) {
+            const region = result[0].region_2depth_name || result[0].region_1depth_name;
+            setQuery(region);
+            fetchHospitals(region);
+          }
+        });
+      },
+      () => setGpsLoading(false)
+    );
   }, []);
 
-  const handleSearch = async () => {
-    const res = await axios.get(`/api/hospitals/search?query=${query}`);
+  const fetchHospitals = async (q) => {
+    const res = await axios.get(`/api/hospitals/search?query=${q}`);
     setHospitals(res.data);
     displayMarkers(res.data);
+    res.data.forEach((h) => loadReviews(h.id));
   };
 
-  const displayMarkers = (hospitals) => {
-    if (typeof window.naver === 'undefined') return;
+  const loadReviews = async (hospitalId) => {
+    const res = await axios.get(`/api/hospitals/${hospitalId}/reviews`);
+    setReviews((prev) => ({ ...prev, [hospitalId]: res.data }));
+  };
 
-    // 기존 마커 제거
+  const displayMarkers = (list) => {
+    if (typeof window.kakao === 'undefined') return;
+    const kakao = window.kakao;
+    const map = mapInstanceRef.current;
+
     markersRef.current.forEach((m) => m.setMap(null));
     markersRef.current = [];
 
-    const map = mapInstanceRef.current;
-    const bounds = new window.naver.maps.LatLngBounds();
+    if (list.length === 0) return;
 
-    hospitals.forEach((hospital) => {
-      const position = new window.naver.maps.LatLng(hospital.lat, hospital.lng);
-      const marker = new window.naver.maps.Marker({
-        position,
-        map,
-        title: hospital.name,
-      });
+    const bounds = new kakao.maps.LatLngBounds();
 
-      // 마커 클릭 시 병원 선택
-      window.naver.maps.Event.addListener(marker, 'click', () => {
-        handleSelectHospital(hospital);
+    list.forEach((hospital) => {
+      const position = new kakao.maps.LatLng(hospital.lat, hospital.lng);
+      const marker = new kakao.maps.Marker({ position, map, title: hospital.name });
+
+      kakao.maps.event.addListener(marker, 'click', () => handleSelectHospital(hospital));
+      kakao.maps.event.addListener(marker, 'mouseover', () => {
+        marker.getMap()?.setCursor('pointer');
       });
 
       markersRef.current.push(marker);
       bounds.extend(position);
     });
 
-    if (hospitals.length > 0) {
-      map.fitBounds(bounds);
-    }
+    map.setBounds(bounds);
   };
 
   const handleSelectHospital = async (hospital) => {
     setSelectedHospital(hospital);
-    const res = await axios.get(`/api/hospitals/${hospital.id}/reviews`);
-    setReviews(res.data);
+    if (!reviews[hospital.id]) await loadReviews(hospital.id);
 
-    // 선택한 병원으로 지도 이동
-    if (mapInstanceRef.current && typeof window.naver !== 'undefined') {
-      mapInstanceRef.current.setCenter(
-        new window.naver.maps.LatLng(hospital.lat, hospital.lng)
-      );
-      mapInstanceRef.current.setZoom(16);
+    if (mapInstanceRef.current) {
+      const kakao = window.kakao;
+      mapInstanceRef.current.setCenter(new kakao.maps.LatLng(hospital.lat, hospital.lng));
+      mapInstanceRef.current.setLevel(4);
     }
+  };
+
+  const handleSearch = () => {
+    if (!query.trim()) return;
+    fetchHospitals(query);
   };
 
   const handleReviewSubmit = async (e) => {
     e.preventDefault();
+    if (!reviewForm.rating) { alert('별점을 선택해주세요.'); return; }
     await axios.post(`/api/hospitals/${selectedHospital.id}/reviews`, {
-      rating: Number(reviewForm.rating),
+      rating: reviewForm.rating,
       content: reviewForm.content,
     });
-    alert('리뷰 등록 완료!');
-    const res = await axios.get(`/api/hospitals/${selectedHospital.id}/reviews`);
-    setReviews(res.data);
-    setReviewForm({ rating: '', content: '' });
+    await loadReviews(selectedHospital.id);
+    setReviewForm({ rating: 0, content: '' });
+  };
+
+  const getAvgRating = (hospitalId) => {
+    const list = reviews[hospitalId];
+    if (!list || list.length === 0) return null;
+    const avg = list.reduce((sum, r) => sum + r.rating, 0) / list.length;
+    return { avg: avg.toFixed(1), count: list.length };
   };
 
   return (
     <div className="max-w-7xl mx-auto">
-      <h1 className="text-3xl font-bold text-gray-800 mb-6">동물병원 찾기</h1>
+      <h1 className="text-3xl font-bold text-gray-800 mb-6">가까운 동물병원</h1>
 
       <div className="flex gap-3 mb-6">
         <Input
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="지역 검색 (예: 강남)"
-          onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
+          onKeyDown={(e) => e.key === 'Enter' && !e.nativeEvent.isComposing && handleSearch()}
           className="flex-1 h-12"
         />
         <Button
           onClick={handleSearch}
           className="bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-700 hover:to-indigo-700 text-white px-8 shadow-md hover:shadow-lg transition-all"
         >
-          검색
+          {gpsLoading ? <Loader2 className="w-4 h-4 animate-spin" /> : '검색'}
         </Button>
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        {/* 지도 */}
         <div className="lg:col-span-1">
           <div className="bg-white rounded-2xl shadow-sm overflow-hidden sticky top-[165px]">
-            <div ref={mapRef} className="w-full h-[500px]" />
+            {gpsLoading && (
+              <div className="flex items-center justify-center gap-2 py-3 text-sm text-purple-600 bg-purple-50 border-b border-purple-100">
+                <Loader2 className="w-4 h-4 animate-spin" />
+                내 위치 찾는 중...
+              </div>
+            )}
+            <div ref={mapRef} className="w-full h-[460px]" />
           </div>
         </div>
 
-        {/* 병원 목록 */}
         <div className="lg:col-span-2 space-y-4">
-          {hospitals.length === 0 && (
+          {hospitals.length === 0 && !gpsLoading && (
             <div className="text-center py-12 bg-white rounded-2xl shadow-sm">
               <div className="text-6xl mb-4">🏥</div>
-              <p className="text-gray-600">
-                지역을 검색하여 동물병원을 찾아보세요
-              </p>
+              <p className="text-gray-600">지역을 검색하여 동물병원을 찾아보세요</p>
             </div>
           )}
-          {hospitals.map((h) => (
-            <div
-              key={h.id}
-              onClick={() => handleSelectHospital(h)}
-              className={`bg-white rounded-2xl shadow-sm p-6 cursor-pointer hover:shadow-md transition-all ${
-                selectedHospital?.id === h.id ? 'ring-2 ring-purple-400' : ''
-              }`}
-            >
-              <h3 className="text-xl font-bold text-gray-800 mb-2">{h.name}</h3>
-              <div className="space-y-1 text-sm text-gray-600">
-                <div className="flex items-center gap-2">
-                  <MapPin className="w-4 h-4 text-purple-600" />
-                  {h.address}
+          {hospitals.map((h) => {
+            const rating = getAvgRating(h.id);
+            const isSelected = selectedHospital?.id === h.id;
+            const hospitalReviews = reviews[h.id] || [];
+
+            return (
+              <div
+                key={h.id}
+                className={`bg-white rounded-2xl shadow-sm overflow-hidden transition-all ${
+                  isSelected ? 'ring-2 ring-purple-400' : 'hover:shadow-md'
+                }`}
+              >
+                <div
+                  onClick={() => handleSelectHospital(h)}
+                  className="p-6 cursor-pointer"
+                >
+                  <div className="flex items-start justify-between mb-2">
+                    <h3 className="text-xl font-bold text-gray-800">{h.name}</h3>
+                    {rating && (
+                      <div className="flex items-center gap-1 text-sm text-gray-500 shrink-0 ml-2">
+                        <Star className="w-4 h-4 fill-yellow-400 text-yellow-400" />
+                        <span className="font-semibold text-gray-700">{rating.avg}</span>
+                        <span>({rating.count})</span>
+                      </div>
+                    )}
+                  </div>
+                  <div className="space-y-1 text-sm text-gray-600">
+                    <div className="flex items-center gap-2">
+                      <MapPin className="w-4 h-4 text-purple-600 shrink-0" />
+                      {h.address}
+                    </div>
+                    {h.phone && (
+                      <div className="flex items-center gap-2">
+                        <Phone className="w-4 h-4 text-purple-600 shrink-0" />
+                        <a
+                          href={`tel:${h.phone}`}
+                          onClick={(e) => e.stopPropagation()}
+                          className="text-purple-600 hover:underline"
+                        >
+                          {h.phone}
+                        </a>
+                      </div>
+                    )}
+                  </div>
                 </div>
-                {h.phone && (
-                  <div className="flex items-center gap-2">
-                    <Phone className="w-4 h-4 text-purple-600" />
-                    {h.phone}
+
+                {isSelected && (
+                  <div className="border-t border-gray-100 px-6 pb-6">
+                    {hospitalReviews.length > 0 && (
+                      <div className={`mt-4 space-y-3 ${hospitalReviews.length >= 6 ? 'max-h-[400px] overflow-y-auto pr-1' : ''}`}>
+                        {hospitalReviews.map((r) => (
+                          <div key={r.id} className="bg-gray-50 rounded-xl p-4">
+                            <div className="flex items-center gap-2 mb-1">
+                              <span className="font-semibold text-sm text-gray-800">{r.nickname}</span>
+                              <StarRating value={r.rating} readonly size="sm" />
+                            </div>
+                            <p className="text-sm text-gray-700">{r.content}</p>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+
+                    <form onSubmit={handleReviewSubmit} className="mt-4 space-y-3">
+                      <p className="text-sm font-semibold text-gray-700">리뷰 작성</p>
+                      <StarRating
+                        value={reviewForm.rating}
+                        onChange={(v) => setReviewForm({ ...reviewForm, rating: v })}
+                      />
+                      <Input
+                        placeholder="리뷰 내용을 입력하세요"
+                        value={reviewForm.content}
+                        onChange={(e) => setReviewForm({ ...reviewForm, content: e.target.value })}
+                        required
+                        className="h-10"
+                      />
+                      <Button
+                        type="submit"
+                        className="w-full bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-700 hover:to-indigo-700 text-white"
+                      >
+                        등록
+                      </Button>
+                    </form>
                   </div>
                 )}
               </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       </div>
-
-      {/* 선택된 병원 리뷰 */}
-      {selectedHospital && (
-        <div className="mt-8 bg-white rounded-2xl shadow-sm p-8">
-          <h2 className="text-2xl font-bold text-gray-800 mb-6">
-            {selectedHospital.name} 리뷰
-          </h2>
-
-          {reviews.length === 0 && (
-            <p className="text-gray-500 text-center py-8">아직 리뷰가 없어요</p>
-          )}
-
-          <div className="space-y-4 mb-8">
-            {reviews.map((r) => (
-              <div key={r.id} className="bg-gray-50 rounded-xl p-4">
-                <div className="flex items-center gap-2 mb-2">
-                  <span className="font-semibold text-gray-800">{r.nickname}</span>
-                  <div className="flex items-center gap-1 text-yellow-500">
-                    <Star className="w-4 h-4 fill-yellow-500" />
-                    <span className="font-semibold">{r.rating}</span>
-                  </div>
-                </div>
-                <p className="text-gray-700">{r.content}</p>
-              </div>
-            ))}
-          </div>
-
-          <div className="border-t border-gray-100 pt-6">
-            <h3 className="text-xl font-bold text-gray-800 mb-4">리뷰 작성</h3>
-            <form onSubmit={handleReviewSubmit} className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="rating">별점 (1-5)</Label>
-                <Input
-                  id="rating"
-                  type="number"
-                  min="1"
-                  max="5"
-                  placeholder="별점 (1-5)"
-                  value={reviewForm.rating}
-                  onChange={(e) => setReviewForm({ ...reviewForm, rating: e.target.value })}
-                  required
-                  className="h-12"
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="content">리뷰 내용</Label>
-                <Input
-                  id="content"
-                  placeholder="리뷰 내용"
-                  value={reviewForm.content}
-                  onChange={(e) => setReviewForm({ ...reviewForm, content: e.target.value })}
-                  required
-                  className="h-12"
-                />
-              </div>
-              <Button
-                type="submit"
-                className="w-full bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-700 hover:to-indigo-700 text-white py-6 shadow-lg hover:shadow-xl transition-all"
-              >
-                리뷰 등록
-              </Button>
-            </form>
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/src/pages/hospital/HospitalPage.jsx
+++ b/src/pages/hospital/HospitalPage.jsx
@@ -145,6 +145,18 @@ export default function HospitalPage() {
     setReviewForm({ rating: 0, content: '' });
   };
 
+  const ORDINALS = ['', '', '두번째', '세번째', '네번째', '다섯번째', '여섯번째', '일곱번째', '여덟번째', '아홉번째', '열번째'];
+
+  const getReviewsWithOrdinal = (hospitalId) => {
+    const list = reviews[hospitalId] || [];
+    const counts = {};
+    return list.map((r) => {
+      counts[r.nickname] = (counts[r.nickname] || 0) + 1;
+      const label = counts[r.nickname] >= 2 ? (ORDINALS[counts[r.nickname]] ?? `${counts[r.nickname]}번째`) + ' 리뷰' : null;
+      return { ...r, visitLabel: label };
+    });
+  };
+
   const getAvgRating = (hospitalId) => {
     const list = reviews[hospitalId];
     if (!list || list.length === 0) return null;
@@ -242,10 +254,15 @@ export default function HospitalPage() {
                   <div className="border-t border-gray-100 px-6 pb-6">
                     {hospitalReviews.length > 0 && (
                       <div className={`mt-4 space-y-3 ${hospitalReviews.length >= 6 ? 'max-h-[400px] overflow-y-auto pr-1' : ''}`}>
-                        {hospitalReviews.map((r) => (
+                        {getReviewsWithOrdinal(h.id).map((r) => (
                           <div key={r.id} className="bg-gray-50 rounded-xl p-4">
                             <div className="flex items-center gap-2 mb-1">
                               <span className="font-semibold text-sm text-gray-800">{r.nickname}</span>
+                              {r.visitLabel && (
+                                <span className="text-xs text-purple-500 bg-purple-50 px-1.5 py-0.5 rounded-full">
+                                  {r.visitLabel}
+                                </span>
+                              )}
                               <StarRating value={r.rating} readonly size="sm" />
                             </div>
                             <p className="text-sm text-gray-700">{r.content}</p>

--- a/src/pages/mypage/MyPage.jsx
+++ b/src/pages/mypage/MyPage.jsx
@@ -1,0 +1,253 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router';
+import axios from '../../api/axios';
+import { Button } from '../../components/ui/button';
+import { Input } from '../../components/ui/input';
+import { Label } from '../../components/ui/label';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../../components/ui/dialog';
+import { Pencil, MapPin, Mail, Calendar, FileText, Footprints, ChevronRight } from 'lucide-react';
+
+const TABS = [
+  { key: 'posts', label: '작성한 글', icon: FileText },
+  { key: 'walks', label: '산책 매칭', icon: Footprints },
+];
+
+export default function MyPage() {
+  const navigate = useNavigate();
+  const [user, setUser] = useState(null);
+  const [myPosts, setMyPosts] = useState([]);
+  const [myWalks, setMyWalks] = useState([]);
+  const [activeTab, setActiveTab] = useState('posts');
+  const [editOpen, setEditOpen] = useState(false);
+  const [editForm, setEditForm] = useState({ nickname: '', address: '' });
+
+  useEffect(() => {
+    axios.get('/api/users/me').then((res) => {
+      setUser(res.data);
+      setEditForm({ nickname: res.data.nickname ?? '', address: res.data.address ?? '' });
+    });
+    axios.get('/api/posts/my').then((res) => setMyPosts(res.data));
+    axios.get('/api/walk-requests/my').then((res) => setMyWalks(res.data)).catch(() => {});
+  }, []);
+
+  const handleGpsAddress = () => {
+    if (!navigator.geolocation) return;
+    navigator.geolocation.getCurrentPosition((pos) => {
+      const { latitude: lat, longitude: lng } = pos.coords;
+      if (typeof window.kakao === 'undefined') return;
+      const geocoder = new window.kakao.maps.services.Geocoder();
+      geocoder.coord2RegionCode(lng, lat, (result, status) => {
+        if (status === window.kakao.maps.services.Status.OK) {
+          const r = result[0];
+          const addr = `${r.region_1depth_name} ${r.region_2depth_name}`;
+          setEditForm((prev) => ({ ...prev, address: addr }));
+        }
+      });
+    });
+  };
+
+  const handleEditSubmit = async (e) => {
+    e.preventDefault();
+    const res = await axios.put('/api/users/me', editForm);
+    setUser(res.data);
+    setEditOpen(false);
+  };
+
+  if (!user) return (
+    <div className="flex items-center justify-center py-24">
+      <div className="text-center">
+        <div className="text-6xl mb-4">🐾</div>
+        <p className="text-gray-500">로딩 중...</p>
+      </div>
+    </div>
+  );
+
+  const initial = (user.nickname ?? user.name ?? '?')[0].toUpperCase();
+
+  return (
+    <div className="max-w-4xl mx-auto space-y-6">
+
+      {/* 프로필 카드 */}
+      <div className="bg-white rounded-2xl shadow-sm p-8">
+        <div className="flex items-center gap-6">
+          <div className="w-20 h-20 rounded-full bg-gradient-to-br from-purple-400 to-indigo-500 flex items-center justify-center text-3xl font-bold text-white shadow-md flex-shrink-0">
+            {initial}
+          </div>
+          <div className="flex-1 min-w-0">
+            <h2 className="text-2xl font-bold text-gray-800">{user.nickname ?? user.name}</h2>
+            <p className="text-gray-500 text-sm mt-0.5">{user.email}</p>
+          </div>
+          <Button
+            onClick={() => setEditOpen(true)}
+            variant="outline"
+            className="border-purple-300 text-purple-600 hover:bg-purple-50 rounded-full shrink-0"
+          >
+            <Pencil className="w-4 h-4 mr-2" />
+            프로필 수정
+          </Button>
+        </div>
+
+        <div className="mt-6 grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <div className="flex items-center gap-3 p-4 bg-gray-50 rounded-xl">
+            <MapPin className="w-5 h-5 text-purple-500 shrink-0" />
+            <div>
+              <p className="text-xs text-gray-400 mb-0.5">주소</p>
+              <p className="text-sm font-medium text-gray-700">{user.address || '미설정'}</p>
+            </div>
+          </div>
+          <div className="flex items-center gap-3 p-4 bg-gray-50 rounded-xl">
+            <Mail className="w-5 h-5 text-purple-500 shrink-0" />
+            <div>
+              <p className="text-xs text-gray-400 mb-0.5">이메일</p>
+              <p className="text-sm font-medium text-gray-700 truncate">{user.email}</p>
+            </div>
+          </div>
+          <div className="flex items-center gap-3 p-4 bg-gray-50 rounded-xl">
+            <Calendar className="w-5 h-5 text-purple-500 shrink-0" />
+            <div>
+              <p className="text-xs text-gray-400 mb-0.5">가입일</p>
+              <p className="text-sm font-medium text-gray-700">
+                {user.createdAt ? new Date(user.createdAt).toLocaleDateString('ko-KR') : '-'}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* 활동 통계 */}
+      <div className="grid grid-cols-2 gap-4">
+        <div className="bg-white rounded-2xl shadow-sm p-6 text-center">
+          <p className="text-3xl font-bold bg-gradient-to-r from-purple-600 to-indigo-600 bg-clip-text text-transparent">
+            {myPosts.length}
+          </p>
+          <p className="text-sm text-gray-500 mt-1">작성한 글</p>
+        </div>
+        <div className="bg-white rounded-2xl shadow-sm p-6 text-center">
+          <p className="text-3xl font-bold bg-gradient-to-r from-purple-600 to-indigo-600 bg-clip-text text-transparent">
+            {myWalks.length}
+          </p>
+          <p className="text-sm text-gray-500 mt-1">산책 매칭</p>
+        </div>
+      </div>
+
+      {/* 최근 활동 탭 */}
+      <div className="bg-white rounded-2xl shadow-sm overflow-hidden">
+        <div className="flex border-b border-gray-100">
+          {TABS.map(({ key, label, icon: Icon }) => (
+            <button
+              key={key}
+              onClick={() => setActiveTab(key)}
+              className={`flex items-center gap-2 flex-1 justify-center py-4 text-sm font-medium transition-colors ${
+                activeTab === key
+                  ? 'text-purple-600 border-b-2 border-purple-600 bg-purple-50'
+                  : 'text-gray-500 hover:text-purple-600 hover:bg-purple-50'
+              }`}
+            >
+              <Icon className="w-4 h-4" />
+              {label}
+            </button>
+          ))}
+        </div>
+
+        <div className="divide-y divide-gray-50">
+          {activeTab === 'posts' && (
+            myPosts.length === 0
+              ? <EmptyState text="아직 작성한 글이 없어요" />
+              : myPosts.map((post) => (
+                <button
+                  key={post.id}
+                  onClick={() => navigate(`/posts/${post.id}`)}
+                  className="w-full text-left px-6 py-4 hover:bg-purple-50 transition-colors flex items-center justify-between gap-4"
+                >
+                  <div className="min-w-0">
+                    <p className="font-medium text-gray-800 truncate">{post.title}</p>
+                    <p className="text-xs text-gray-400 mt-0.5">
+                      {new Date(post.createdAt).toLocaleDateString('ko-KR')}
+                      {post.category && ` · ${post.category}`}
+                    </p>
+                  </div>
+                  <ChevronRight className="w-4 h-4 text-gray-300 shrink-0" />
+                </button>
+              ))
+          )}
+
+          {activeTab === 'walks' && (
+            myWalks.length === 0
+              ? <EmptyState text="아직 등록한 산책 매칭이 없어요" />
+              : myWalks.map((walk) => (
+                <div key={walk.id} className="px-6 py-4">
+                  <p className="font-medium text-gray-800">{walk.title}</p>
+                  <p className="text-xs text-gray-400 mt-0.5">
+                    {walk.walkDate} · {walk.startTime}~{walk.endTime}
+                    {walk.location && ` · ${walk.location}`}
+                  </p>
+                  {walk.reward && (
+                    <span className="inline-block mt-1.5 text-xs text-purple-600 bg-purple-50 px-2 py-0.5 rounded-full">
+                      {walk.reward}
+                    </span>
+                  )}
+                </div>
+              ))
+          )}
+        </div>
+      </div>
+
+      {/* 프로필 수정 모달 */}
+      <Dialog open={editOpen} onOpenChange={setEditOpen}>
+        <DialogContent className="max-w-sm">
+          <DialogHeader>
+            <DialogTitle>프로필 수정</DialogTitle>
+          </DialogHeader>
+          <form onSubmit={handleEditSubmit} className="space-y-4 mt-2">
+            <div className="space-y-2">
+              <Label>닉네임</Label>
+              <Input
+                value={editForm.nickname}
+                onChange={(e) => setEditForm({ ...editForm, nickname: e.target.value })}
+                placeholder="닉네임"
+                required
+                className="h-11"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>주소</Label>
+              <div className="flex gap-2">
+                <Input
+                  value={editForm.address}
+                  onChange={(e) => setEditForm({ ...editForm, address: e.target.value })}
+                  placeholder="예: 서울시 강남구"
+                  className="h-11 flex-1"
+                />
+                <Button
+                  type="button"
+                  onClick={handleGpsAddress}
+                  variant="outline"
+                  className="border-purple-300 text-purple-600 hover:bg-purple-50 shrink-0"
+                  title="현재 위치로 자동 입력"
+                >
+                  <MapPin className="w-4 h-4" />
+                </Button>
+              </div>
+              <p className="text-xs text-gray-400">📍 버튼으로 현재 위치 자동 입력</p>
+            </div>
+            <Button
+              type="submit"
+              className="w-full bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-700 hover:to-indigo-700 text-white"
+            >
+              저장
+            </Button>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function EmptyState({ text }) {
+  return (
+    <div className="text-center py-12">
+      <div className="text-5xl mb-3">🐾</div>
+      <p className="text-gray-500 text-sm">{text}</p>
+    </div>
+  );
+}

--- a/src/pages/walk/WalkRequestPage.jsx
+++ b/src/pages/walk/WalkRequestPage.jsx
@@ -125,10 +125,17 @@ export default function WalkRequestPage() {
 
   const handleStartTimeChange = (e) => {
     const newStart = e.target.value;
+    if (!newStart) {
+      setForm((prev) => ({ ...prev, startTime: '', endTime: '' }));
+      return;
+    }
+    const [h, m] = newStart.split(':').map(Number);
+    const totalMin = h * 60 + m + 1;
+    const autoEnd = `${String(Math.floor(totalMin / 60) % 24).padStart(2, '0')}:${String(totalMin % 60).padStart(2, '0')}`;
     setForm((prev) => ({
       ...prev,
       startTime: newStart,
-      endTime: prev.endTime && prev.endTime <= newStart ? '' : prev.endTime,
+      endTime: autoEnd,
     }));
   };
 

--- a/src/pages/walk/WalkRequestPage.jsx
+++ b/src/pages/walk/WalkRequestPage.jsx
@@ -78,6 +78,15 @@ export default function WalkRequestPage() {
     setForm({ ...form, petId: value });
   };
 
+  const handleRewardChange = (e) => {
+    const digits = e.target.value.replace(/[^0-9]/g, '');
+    if (!digits) {
+      setForm({ ...form, reward: '' });
+      return;
+    }
+    setForm({ ...form, reward: Number(digits).toLocaleString('ko-KR') + '원' });
+  };
+
   const handleSubmit = async (e) => {
     e.preventDefault();
     const res = await axios.post('/api/walk-requests', {
@@ -200,9 +209,9 @@ export default function WalkRequestPage() {
                 <Input
                   id="reward"
                   name="reward"
-                  placeholder="예: 시간당 10,000원"
+                  placeholder="예: 10,000원"
                   value={form.reward}
-                  onChange={handleChange}
+                  onChange={handleRewardChange}
                   required
                   className="h-10"
                 />

--- a/src/pages/walk/WalkRequestPage.jsx
+++ b/src/pages/walk/WalkRequestPage.jsx
@@ -28,6 +28,7 @@ export default function WalkRequestPage() {
   const [showMap, setShowMap] = useState(false);
   const [mapQuery, setMapQuery] = useState('');
   const [pendingAddress, setPendingAddress] = useState('');
+  const [searchResults, setSearchResults] = useState([]);
   const mapRef = useRef(null);
   const mapInstanceRef = useRef(null);
   const markerRef = useRef(null);
@@ -82,20 +83,26 @@ export default function WalkRequestPage() {
 
     placesRef.current.keywordSearch(mapQuery, (data, status) => {
       if (status !== kakao.maps.services.Status.OK) {
+        setSearchResults([]);
         alert('검색 결과가 없습니다.');
         return;
       }
-      const place = data[0];
-      const latlng = new kakao.maps.LatLng(place.y, place.x);
-
-      mapInstanceRef.current.setCenter(latlng);
-      mapInstanceRef.current.setLevel(4);
-
-      if (markerRef.current) markerRef.current.setMap(null);
-      markerRef.current = new kakao.maps.Marker({ position: latlng, map: mapInstanceRef.current });
-
-      setPendingAddress(place.road_address_name || place.address_name);
+      setSearchResults(data);
     });
+  };
+
+  const handleSelectPlace = (place) => {
+    const kakao = window.kakao;
+    const latlng = new kakao.maps.LatLng(place.y, place.x);
+
+    mapInstanceRef.current.setCenter(latlng);
+    mapInstanceRef.current.setLevel(4);
+
+    if (markerRef.current) markerRef.current.setMap(null);
+    markerRef.current = new kakao.maps.Marker({ position: latlng, map: mapInstanceRef.current });
+
+    setPendingAddress(place.road_address_name || place.address_name);
+    setSearchResults([]);
   };
 
   const handleMapConfirm = () => {
@@ -367,31 +374,52 @@ export default function WalkRequestPage() {
         </div>
       </div>
 
-      <Dialog open={showMap} onOpenChange={(open) => { if (!open) { setPendingAddress(''); setMapQuery(''); } setShowMap(open); }}>
+      <Dialog open={showMap} onOpenChange={(open) => { if (!open) { setPendingAddress(''); setMapQuery(''); setSearchResults([]); } setShowMap(open); }}>
         <DialogContent className="max-w-3xl">
           <DialogHeader>
             <DialogTitle>📍 위치 선택</DialogTitle>
           </DialogHeader>
 
-          <div className="flex gap-2 mb-3">
-            <Input
-              placeholder="장소 또는 주소 검색"
-              value={mapQuery}
-              onChange={(e) => setMapQuery(e.target.value)}
-              onKeyDown={(e) => e.key === 'Enter' && !e.nativeEvent.isComposing && handleMapSearch()}
-              className="flex-1"
-            />
-            <Button
-              type="button"
-              onClick={handleMapSearch}
-              variant="outline"
-              className="border-purple-300 text-purple-600 hover:bg-purple-50"
-            >
-              <Search className="w-4 h-4" />
-            </Button>
+          <div className="relative">
+            <div className="flex gap-2">
+              <Input
+                placeholder="장소 또는 주소 검색"
+                value={mapQuery}
+                onChange={(e) => setMapQuery(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && !e.nativeEvent.isComposing && handleMapSearch()}
+                className="flex-1"
+              />
+              <Button
+                type="button"
+                onClick={handleMapSearch}
+                variant="outline"
+                className="border-purple-300 text-purple-600 hover:bg-purple-50"
+              >
+                <Search className="w-4 h-4" />
+              </Button>
+            </div>
+
+            {searchResults.length > 0 && (
+              <ul className="absolute top-full left-0 right-0 z-50 mt-1 bg-white border border-gray-200 rounded-xl shadow-lg max-h-52 overflow-y-auto">
+                {searchResults.map((place, i) => (
+                  <li key={i}>
+                    <button
+                      type="button"
+                      onClick={() => handleSelectPlace(place)}
+                      className="w-full text-left px-4 py-3 hover:bg-purple-50 transition-colors border-b border-gray-50 last:border-0"
+                    >
+                      <p className="font-medium text-gray-800 text-sm">{place.place_name}</p>
+                      <p className="text-xs text-gray-500 mt-0.5">
+                        {place.road_address_name || place.address_name}
+                      </p>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
           </div>
 
-          <div ref={mapRef} className="w-full h-[420px] rounded-xl" />
+          <div ref={mapRef} className="w-full h-[380px] rounded-xl mt-3" />
 
           <div className="flex items-center justify-between mt-3">
             <p className="text-sm text-gray-500 truncate flex-1 mr-4">

--- a/src/pages/walk/WalkRequestPage.jsx
+++ b/src/pages/walk/WalkRequestPage.jsx
@@ -98,11 +98,8 @@ export default function WalkRequestPage() {
       const res = await axios.post(`/api/chat/rooms?walkRequestId=${request.id}&receiverId=${request.userId}`);
       navigate('/chat', { state: { roomId: res.data.id } });
     } catch (err) {
-      if (err.response?.data?.includes('이미 존재하는')) {
-        navigate('/chat');
-      } else {
-        alert('채팅방 생성 실패');
-      }
+      alert('이미 채팅방이 만들어져 있습니다.');
+      navigate('/chat');
     }
   };
 

--- a/src/pages/walk/WalkRequestPage.jsx
+++ b/src/pages/walk/WalkRequestPage.jsx
@@ -8,7 +8,14 @@ import { Label } from '../../components/ui/label';
 import { Textarea } from '../../components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../../components/ui/select';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../../components/ui/dialog';
-import { Plus, MessageCircle, MapPin, Calendar, Clock } from 'lucide-react';
+import { Plus, MessageCircle, MapPin, Calendar, Clock, Search } from 'lucide-react';
+
+const TODAY = new Date().toISOString().split('T')[0];
+
+const getNowTime = () => {
+  const now = new Date();
+  return `${String(now.getHours()).padStart(2, '0')}:${String(now.getMinutes()).padStart(2, '0')}`;
+};
 
 export default function WalkRequestPage() {
   const [requests, setRequests] = useState([]);
@@ -19,9 +26,13 @@ export default function WalkRequestPage() {
     reward: '', location: ''
   });
   const [showMap, setShowMap] = useState(false);
+  const [mapQuery, setMapQuery] = useState('');
+  const [pendingAddress, setPendingAddress] = useState('');
   const mapRef = useRef(null);
   const mapInstanceRef = useRef(null);
   const markerRef = useRef(null);
+  const geocoderRef = useRef(null);
+  const placesRef = useRef(null);
   const navigate = useNavigate();
   const userId = useAuthStore((state) => state.userId);
 
@@ -34,44 +45,91 @@ export default function WalkRequestPage() {
     if (!showMap) return;
 
     setTimeout(() => {
-      if (typeof window.naver === 'undefined') {
-        alert('네이버 지도 API를 사용할 수 없습니다.');
+      if (typeof window.kakao === 'undefined') {
+        alert('카카오 지도 API를 사용할 수 없습니다.');
         setShowMap(false);
         return;
       }
 
-      const map = new window.naver.maps.Map(mapRef.current, {
-        center: new window.naver.maps.LatLng(37.5665, 126.9780),
-        zoom: 14,
+      const kakao = window.kakao;
+      const map = new kakao.maps.Map(mapRef.current, {
+        center: new kakao.maps.LatLng(37.5665, 126.9780),
+        level: 5,
       });
       mapInstanceRef.current = map;
+      geocoderRef.current = new kakao.maps.services.Geocoder();
+      placesRef.current = new kakao.maps.services.Places();
 
-      window.naver.maps.Event.addListener(map, 'click', (e) => {
-        const lat = e.coord.lat();
-        const lng = e.coord.lng();
+      kakao.maps.event.addListener(map, 'click', (mouseEvent) => {
+        const latlng = mouseEvent.latLng;
 
         if (markerRef.current) markerRef.current.setMap(null);
-        markerRef.current = new window.naver.maps.Marker({
-          position: e.coord,
-          map,
-        });
+        markerRef.current = new kakao.maps.Marker({ position: latlng, map });
 
-        window.naver.maps.Service.reverseGeocode(
-          { coords: new window.naver.maps.LatLng(lat, lng) },
-          (status, response) => {
-            if (status === window.naver.maps.Service.Status.OK) {
-              const address = response.v2.address.jibunAddress || response.v2.address.roadAddress;
-              setForm((prev) => ({ ...prev, location: address }));
-              setShowMap(false);
-            }
+        geocoderRef.current.coord2Address(latlng.getLng(), latlng.getLat(), (result, status) => {
+          if (status === kakao.maps.services.Status.OK) {
+            const addr = result[0].road_address?.address_name || result[0].address.address_name;
+            setPendingAddress(addr);
           }
-        );
+        });
       });
     }, 100);
   }, [showMap]);
 
+  const handleMapSearch = () => {
+    if (!mapQuery.trim() || !placesRef.current) return;
+    const kakao = window.kakao;
+
+    placesRef.current.keywordSearch(mapQuery, (data, status) => {
+      if (status !== kakao.maps.services.Status.OK) {
+        alert('검색 결과가 없습니다.');
+        return;
+      }
+      const place = data[0];
+      const latlng = new kakao.maps.LatLng(place.y, place.x);
+
+      mapInstanceRef.current.setCenter(latlng);
+      mapInstanceRef.current.setLevel(4);
+
+      if (markerRef.current) markerRef.current.setMap(null);
+      markerRef.current = new kakao.maps.Marker({ position: latlng, map: mapInstanceRef.current });
+
+      setPendingAddress(place.road_address_name || place.address_name);
+    });
+  };
+
+  const handleMapConfirm = () => {
+    if (!pendingAddress) {
+      alert('지도에서 위치를 선택해주세요.');
+      return;
+    }
+    setForm((prev) => ({ ...prev, location: pendingAddress }));
+    setShowMap(false);
+    setPendingAddress('');
+    setMapQuery('');
+  };
+
   const handleChange = (e) => {
     setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleDateChange = (e) => {
+    const newDate = e.target.value;
+    setForm((prev) => ({
+      ...prev,
+      walkDate: newDate,
+      startTime: newDate === TODAY && prev.startTime < getNowTime() ? '' : prev.startTime,
+      endTime: newDate === TODAY && prev.startTime < getNowTime() ? '' : prev.endTime,
+    }));
+  };
+
+  const handleStartTimeChange = (e) => {
+    const newStart = e.target.value;
+    setForm((prev) => ({
+      ...prev,
+      startTime: newStart,
+      endTime: prev.endTime && prev.endTime <= newStart ? '' : prev.endTime,
+    }));
   };
 
   const handlePetChange = (value) => {
@@ -171,7 +229,8 @@ export default function WalkRequestPage() {
                   name="walkDate"
                   type="date"
                   value={form.walkDate}
-                  onChange={handleChange}
+                  onChange={handleDateChange}
+                  min={TODAY}
                   required
                   className="h-10"
                 />
@@ -185,7 +244,8 @@ export default function WalkRequestPage() {
                     name="startTime"
                     type="time"
                     value={form.startTime}
-                    onChange={handleChange}
+                    onChange={handleStartTimeChange}
+                    min={form.walkDate === TODAY ? getNowTime() : undefined}
                     required
                     className="h-10"
                   />
@@ -198,6 +258,7 @@ export default function WalkRequestPage() {
                     type="time"
                     value={form.endTime}
                     onChange={handleChange}
+                    min={form.startTime || undefined}
                     required
                     className="h-10"
                   />
@@ -299,12 +360,45 @@ export default function WalkRequestPage() {
         </div>
       </div>
 
-      <Dialog open={showMap} onOpenChange={setShowMap}>
-        <DialogContent className="max-w-3xl max-h-[80vh]">
+      <Dialog open={showMap} onOpenChange={(open) => { if (!open) { setPendingAddress(''); setMapQuery(''); } setShowMap(open); }}>
+        <DialogContent className="max-w-3xl">
           <DialogHeader>
-            <DialogTitle>📍 지도에서 위치를 클릭하세요</DialogTitle>
+            <DialogTitle>📍 위치 선택</DialogTitle>
           </DialogHeader>
-          <div ref={mapRef} className="w-full h-[500px] rounded-xl" />
+
+          <div className="flex gap-2 mb-3">
+            <Input
+              placeholder="장소 또는 주소 검색"
+              value={mapQuery}
+              onChange={(e) => setMapQuery(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && !e.nativeEvent.isComposing && handleMapSearch()}
+              className="flex-1"
+            />
+            <Button
+              type="button"
+              onClick={handleMapSearch}
+              variant="outline"
+              className="border-purple-300 text-purple-600 hover:bg-purple-50"
+            >
+              <Search className="w-4 h-4" />
+            </Button>
+          </div>
+
+          <div ref={mapRef} className="w-full h-[420px] rounded-xl" />
+
+          <div className="flex items-center justify-between mt-3">
+            <p className="text-sm text-gray-500 truncate flex-1 mr-4">
+              {pendingAddress ? `📍 ${pendingAddress}` : '지도를 클릭하거나 검색해서 위치를 선택하세요'}
+            </p>
+            <Button
+              type="button"
+              onClick={handleMapConfirm}
+              disabled={!pendingAddress}
+              className="bg-gradient-to-r from-purple-600 to-indigo-600 hover:from-purple-700 hover:to-indigo-700 text-white rounded-full px-6 disabled:opacity-40"
+            >
+              선택 완료
+            </Button>
+          </div>
         </DialogContent>
       </Dialog>
     </div>

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -9,6 +9,7 @@ import PetPage from "./pages/pet/PetPage";
 import WalkRequestPage from "./pages/walk/WalkRequestPage";
 import HospitalPage from "./pages/hospital/HospitalPage";
 import ChatPage from "./pages/chat/ChatPage";
+import MyPage from "./pages/mypage/MyPage";
 import useAuthStore from "./store/authStore";
 
 function PrivateRoute({ children }) {
@@ -36,6 +37,7 @@ export const router = createBrowserRouter([
       { path: "walk", element: <WalkRequestPage /> },
       { path: "hospital", element: <HospitalPage /> },
       { path: "chat", element: <ChatPage /> },
+      { path: "mypage", element: <MyPage /> },
     ],
   },
 ]);

--- a/src/store/errorStore.js
+++ b/src/store/errorStore.js
@@ -1,0 +1,10 @@
+import { create } from 'zustand';
+
+const useErrorStore = create((set) => ({
+  networkError: false,
+  sessionExpired: false,
+  setNetworkError: (v) => set({ networkError: v }),
+  setSessionExpired: (v) => set({ sessionExpired: v }),
+}));
+
+export default useErrorStore;


### PR DESCRIPTION
### 📌 개요
네이버 지도 API를 카카오 지도 API로 전환하고, 채팅·동물병원·산책 매칭·커뮤니티 전반의 UX를 개선합니다.

### 🔍 변경 사유
- **기술적 개선:** Kakao Maps API로 전환하여 더 안정적인 지도 서비스 제공
- **사용자 경험:** 에러 상황(서버 다운, 세션 만료) 시 명확한 안내 제공
- **사용자 경험:** 채팅·병원·산책 등 각 기능의 세부 UX 개선

### 🛠 작업 내용

**지도 전환 (closes #28)**
- [x] index.html Naver → Kakao Maps SDK 교체
- [x] 산책 매칭, 동물병원 지도 Kakao Maps 기반으로 재구현

**에러 처리 (closes #29)**
- [x] 네트워크 에러 / 세션 만료 시 재로그인 안내 모달
- [x] Zustand errorStore로 전역 에러 상태 관리

**채팅 개선 (closes #6, closes #7, closes #30)**
- [x] 한국어 IME Enter 중복 전송 방지
- [x] 채팅방 목록 항상 가로 배치, 상대방 이름·아이콘 표시
- [x] 채팅방 생성 실패 메시지 개선

**동물병원 개선 (closes #15, closes #31)**
- [x] 진입 시 GPS 자동 감지 → 주변 병원 자동 검색
- [x] 네비바 '동물병원' → '가까운 동물병원'
- [x] 전화번호 → 전화하기 버튼
- [x] 재방문 리뷰 순서 뱃지 (두번째/세번째 리뷰)

**산책 매칭 개선 (closes #12, closes #13, closes #32)**
- [x] 알바비 자동 포맷 (10000 → 10,000원)
- [x] 날짜/시간 유효성 (과거 선택 불가, 종료 시간 자동 +1분)
- [x] 지도 검색 결과 목록 표시 및 선택

**커뮤니티 개선 (closes #4)**
- [x] 좋아요 상태 localStorage 유지 (페이지 이동 후 복원)

**마이페이지 (closes #11)**
- [x] 닉네임, 이메일, 주소, 가입일 표시
- [x] 프로필 수정 (닉네임·주소, GPS 자동 입력)
- [x] 작성한 글 / 산책 매칭 탭 조회

🤖 Generated with [Claude Code](https://claude.ai/claude-code)