### PR TITLE
feat: 카카오 소셜 로그인 연동

### DIFF
--- a/src/components/KakaoLoginButton.jsx
+++ b/src/components/KakaoLoginButton.jsx
@@ -1,0 +1,31 @@
+const KAKAO_REST_API_KEY = import.meta.env.VITE_KAKAO_REST_API_KEY;
+
+export default function KakaoLoginButton({ label = '카카오로 계속하기' }) {
+  const handleKakaoLogin = () => {
+    const redirectUri = `${window.location.origin}/oauth/kakao`;
+    window.location.href =
+      `https://kauth.kakao.com/oauth/authorize?client_id=${KAKAO_REST_API_KEY}&redirect_uri=${encodeURIComponent(redirectUri)}&response_type=code`;
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleKakaoLogin}
+      className="w-full flex items-center justify-center gap-3 py-3 bg-[#FEE500] hover:bg-[#F5DC00] text-[#191919] font-medium rounded-xl transition-colors"
+    >
+      <KakaoIcon />
+      {label}
+    </button>
+  );
+}
+
+function KakaoIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none">
+      <path
+        d="M12 3C7.029 3 3 6.36 3 10.5c0 2.625 1.696 4.928 4.271 6.244L6.2 20.1a.375.375 0 0 0 .545.415L11.1 18.04c.296.022.595.034.9.034 4.971 0 9-3.36 9-7.5S16.971 3 12 3z"
+        fill="#191919"
+      />
+    </svg>
+  );
+}

--- a/src/pages/auth/KakaoCallback.jsx
+++ b/src/pages/auth/KakaoCallback.jsx
@@ -1,0 +1,66 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router';
+import axios from '../../api/axios';
+import useAuthStore from '../../store/authStore';
+
+export default function KakaoCallback() {
+  const navigate = useNavigate();
+  const setLoggedIn = useAuthStore((state) => state.setLoggedIn);
+  const setUserId = useAuthStore((state) => state.setUserId);
+  const setUserInfo = useAuthStore((state) => state.setUserInfo);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get('code');
+    // 카카오에 넘긴 redirectUri와 정확히 동일한 값이어야 토큰 교환이 성공합니다
+    const redirectUri = `${window.location.origin}/oauth/kakao`;
+
+    if (!code) {
+      navigate('/login');
+      return;
+    }
+
+    axios.post('/api/auth/kakao', { code, redirectUri })
+      .then((res) => {
+        localStorage.setItem('accessToken', res.data.accessToken);
+        localStorage.setItem('refreshToken', res.data.refreshToken);
+        setLoggedIn(true);
+        setUserId(res.data.userId);
+        if (res.data.email || res.data.nickname) {
+          setUserInfo({ email: res.data.email, nickname: res.data.nickname });
+        }
+        navigate('/');
+      })
+      .catch(() => {
+        setError(true);
+      });
+  }, []);
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-purple-50 via-purple-50/50 to-indigo-50 flex items-center justify-center p-4">
+        <div className="bg-white rounded-3xl shadow-xl p-8 text-center max-w-sm w-full">
+          <div className="text-5xl mb-4">😢</div>
+          <h2 className="text-xl font-bold text-gray-800 mb-2">카카오 로그인 실패</h2>
+          <p className="text-gray-500 text-sm mb-6">인증 중 오류가 발생했습니다. 다시 시도해주세요.</p>
+          <button
+            onClick={() => navigate('/login')}
+            className="w-full py-3 bg-gradient-to-r from-purple-600 to-indigo-600 text-white rounded-xl font-medium hover:from-purple-700 hover:to-indigo-700 transition-all"
+          >
+            로그인 페이지로 돌아가기
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-purple-50 via-purple-50/50 to-indigo-50 flex items-center justify-center">
+      <div className="text-center">
+        <div className="text-6xl mb-4 animate-bounce">🐾</div>
+        <p className="text-gray-500">카카오 로그인 처리 중...</p>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/auth/LoginPage.jsx
+++ b/src/pages/auth/LoginPage.jsx
@@ -5,12 +5,14 @@ import axios from '../../api/axios';
 import { Input } from '../../components/ui/input';
 import { Button } from '../../components/ui/button';
 import { Label } from '../../components/ui/label';
+import KakaoLoginButton from '../../components/KakaoLoginButton';
 
 export default function LoginPage() {
   const [form, setForm] = useState({ email: '', password: '' });
   const navigate = useNavigate();
   const setLoggedIn = useAuthStore((state) => state.setLoggedIn);
   const setUserId = useAuthStore((state) => state.setUserId);
+  const setUserInfo = useAuthStore((state) => state.setUserInfo);
 
   const handleChange = (e) => {
     setForm({ ...form, [e.target.name]: e.target.value });
@@ -24,6 +26,7 @@ export default function LoginPage() {
       localStorage.setItem('refreshToken', res.data.refreshToken);
       setLoggedIn(true);
       setUserId(res.data.userId);
+      setUserInfo({ email: form.email, nickname: res.data.nickname });
       navigate('/');
     } catch (err) {
       alert('로그인 실패');
@@ -84,6 +87,16 @@ export default function LoginPage() {
               로그인
             </Button>
           </form>
+
+          <div className="mt-6 flex items-center gap-3">
+            <div className="flex-1 h-px bg-gray-200" />
+            <span className="text-sm text-gray-400">또는</span>
+            <div className="flex-1 h-px bg-gray-200" />
+          </div>
+
+          <div className="mt-4">
+            <KakaoLoginButton label="카카오로 로그인" />
+          </div>
 
           <div className="mt-6 text-center">
             <p className="text-gray-600">

--- a/src/pages/auth/SignUpPage.jsx
+++ b/src/pages/auth/SignUpPage.jsx
@@ -4,6 +4,7 @@ import axios from '../../api/axios';
 import { Input } from '../../components/ui/input';
 import { Button } from '../../components/ui/button';
 import { Label } from '../../components/ui/label';
+import KakaoLoginButton from '../../components/KakaoLoginButton';
 
 export default function SignUpPage() {
   const [form, setForm] = useState({ email: '', password: '', nickname: '' });
@@ -92,6 +93,16 @@ export default function SignUpPage() {
               회원가입
             </Button>
           </form>
+
+          <div className="mt-6 flex items-center gap-3">
+            <div className="flex-1 h-px bg-gray-200" />
+            <span className="text-sm text-gray-400">또는</span>
+            <div className="flex-1 h-px bg-gray-200" />
+          </div>
+
+          <div className="mt-4">
+            <KakaoLoginButton label="카카오로 회원가입" />
+          </div>
 
           <div className="mt-6 text-center">
             <p className="text-gray-600">

--- a/src/pages/mypage/MyPage.jsx
+++ b/src/pages/mypage/MyPage.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router';
 import axios from '../../api/axios';
+import useAuthStore from '../../store/authStore';
 import { Button } from '../../components/ui/button';
 import { Input } from '../../components/ui/input';
 import { Label } from '../../components/ui/label';
@@ -14,19 +15,39 @@ const TABS = [
 
 export default function MyPage() {
   const navigate = useNavigate();
-  const [user, setUser] = useState(null);
+  const { userEmail, userNickname, setUserInfo } = useAuthStore();
+
+  const [user, setUser] = useState({
+    nickname: userNickname || '',
+    email: userEmail || '',
+    address: '',
+    createdAt: null,
+  });
   const [myPosts, setMyPosts] = useState([]);
   const [myWalks, setMyWalks] = useState([]);
   const [activeTab, setActiveTab] = useState('posts');
   const [editOpen, setEditOpen] = useState(false);
-  const [editForm, setEditForm] = useState({ nickname: '', address: '' });
+  const [editForm, setEditForm] = useState({ nickname: userNickname || '', address: '' });
 
   useEffect(() => {
-    axios.get('/api/users/me').then((res) => {
-      setUser(res.data);
-      setEditForm({ nickname: res.data.nickname ?? '', address: res.data.address ?? '' });
-    });
-    axios.get('/api/posts/my').then((res) => setMyPosts(res.data));
+    axios.get('/api/users/me')
+      .then((res) => {
+        const data = res.data;
+        setUser({
+          nickname: data.nickname || userNickname || '',
+          email: data.email || userEmail || '',
+          address: data.address || '',
+          createdAt: data.createdAt || null,
+        });
+        setEditForm({
+          nickname: data.nickname || userNickname || '',
+          address: data.address || '',
+        });
+        if (data.nickname) setUserInfo({ email: data.email, nickname: data.nickname });
+      })
+      .catch(() => {});
+
+    axios.get('/api/posts/my').then((res) => setMyPosts(res.data)).catch(() => {});
     axios.get('/api/walk-requests/my').then((res) => setMyWalks(res.data)).catch(() => {});
   }, []);
 
@@ -48,21 +69,28 @@ export default function MyPage() {
 
   const handleEditSubmit = async (e) => {
     e.preventDefault();
-    const res = await axios.put('/api/users/me', editForm);
-    setUser(res.data);
+    try {
+      const res = await axios.put('/api/users/me', editForm);
+      const updated = res.data;
+      setUser((prev) => ({
+        ...prev,
+        nickname: updated.nickname || editForm.nickname,
+        address: updated.address || editForm.address,
+      }));
+      setUserInfo({ email: user.email, nickname: updated.nickname || editForm.nickname });
+    } catch {
+      setUser((prev) => ({
+        ...prev,
+        nickname: editForm.nickname,
+        address: editForm.address,
+      }));
+      setUserInfo({ email: user.email, nickname: editForm.nickname });
+    }
     setEditOpen(false);
   };
 
-  if (!user) return (
-    <div className="flex items-center justify-center py-24">
-      <div className="text-center">
-        <div className="text-6xl mb-4">🐾</div>
-        <p className="text-gray-500">로딩 중...</p>
-      </div>
-    </div>
-  );
-
-  const initial = (user.nickname ?? user.name ?? '?')[0].toUpperCase();
+  const displayName = user.nickname || user.email?.split('@')[0] || '사용자';
+  const initial = displayName[0].toUpperCase();
 
   return (
     <div className="max-w-4xl mx-auto space-y-6">
@@ -74,7 +102,7 @@ export default function MyPage() {
             {initial}
           </div>
           <div className="flex-1 min-w-0">
-            <h2 className="text-2xl font-bold text-gray-800">{user.nickname ?? user.name}</h2>
+            <h2 className="text-2xl font-bold text-gray-800">{displayName}</h2>
             <p className="text-gray-500 text-sm mt-0.5">{user.email}</p>
           </div>
           <Button
@@ -99,7 +127,7 @@ export default function MyPage() {
             <Mail className="w-5 h-5 text-purple-500 shrink-0" />
             <div>
               <p className="text-xs text-gray-400 mb-0.5">이메일</p>
-              <p className="text-sm font-medium text-gray-700 truncate">{user.email}</p>
+              <p className="text-sm font-medium text-gray-700 truncate">{user.email || '-'}</p>
             </div>
           </div>
           <div className="flex items-center gap-3 p-4 bg-gray-50 rounded-xl">

--- a/src/pages/pet/PetPage.jsx
+++ b/src/pages/pet/PetPage.jsx
@@ -20,9 +20,19 @@ export default function PetPage() {
     axios.get('/api/pets/my').then((res) => setPets(res.data));
   }, []);
 
+  const [errors, setErrors] = useState({});
+
   const handleChange = (e) => {
     const value = e.target.type === 'checkbox' ? e.target.checked : e.target.value;
     setForm({ ...form, [e.target.name]: value });
+
+    if ((e.target.name === 'age' || e.target.name === 'weight') && value !== '') {
+      if (Number(value) < 0) {
+        setErrors((prev) => ({ ...prev, [e.target.name]: '0 이상의 값을 입력해주세요.' }));
+      } else {
+        setErrors((prev) => ({ ...prev, [e.target.name]: undefined }));
+      }
+    }
   };
 
   const handleSpeciesChange = (value) => {
@@ -35,6 +45,7 @@ export default function PetPage() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    if (errors.age || errors.weight) return;
     const res = await axios.post('/api/pets', {
       ...form,
       age: form.age ? Number(form.age) : null,
@@ -42,6 +53,7 @@ export default function PetPage() {
     });
     setPets([...pets, res.data]);
     setForm({ name: '', species: '', breed: '', age: '', gender: '', weight: '', description: '', isNeutered: false });
+    setErrors({});
     setShowForm(false);
     alert('펫 등록 완료!');
   };
@@ -119,8 +131,9 @@ export default function PetPage() {
                   placeholder="나이"
                   value={form.age}
                   onChange={handleChange}
-                  className="h-12"
+                  className={`h-12 ${errors.age ? 'border-red-400 focus-visible:ring-red-400' : ''}`}
                 />
+                {errors.age && <p className="text-xs text-red-500">{errors.age}</p>}
               </div>
 
               <div className="space-y-2">
@@ -146,8 +159,9 @@ export default function PetPage() {
                   placeholder="몸무게"
                   value={form.weight}
                   onChange={handleChange}
-                  className="h-12"
+                  className={`h-12 ${errors.weight ? 'border-red-400 focus-visible:ring-red-400' : ''}`}
                 />
+                {errors.weight && <p className="text-xs text-red-500">{errors.weight}</p>}
               </div>
             </div>
 

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -10,6 +10,7 @@ import WalkRequestPage from "./pages/walk/WalkRequestPage";
 import HospitalPage from "./pages/hospital/HospitalPage";
 import ChatPage from "./pages/chat/ChatPage";
 import MyPage from "./pages/mypage/MyPage";
+import KakaoCallback from "./pages/auth/KakaoCallback";
 import useAuthStore from "./store/authStore";
 
 function PrivateRoute({ children }) {
@@ -25,6 +26,10 @@ export const router = createBrowserRouter([
   {
     path: "/signup",
     element: <SignUpPage />,
+  },
+  {
+    path: "/oauth/kakao",
+    element: <KakaoCallback />,
   },
   {
     path: "/",

--- a/src/store/authStore.js
+++ b/src/store/authStore.js
@@ -3,10 +3,20 @@ import { create } from 'zustand';
 const useAuthStore = create((set) => ({
     isLoggedIn: !!localStorage.getItem('accessToken'),
     userId: Number(localStorage.getItem('userId')),
+    userEmail: localStorage.getItem('userEmail') || '',
+    userNickname: localStorage.getItem('userNickname') || '',
     setLoggedIn: (value) => set({ isLoggedIn: value }),
     setUserId: (id) => {
         localStorage.setItem('userId', id);
         set({ userId: id });
+    },
+    setUserInfo: ({ email, nickname }) => {
+        if (email) localStorage.setItem('userEmail', email);
+        if (nickname) localStorage.setItem('userNickname', nickname);
+        set({
+            userEmail: email || '',
+            userNickname: nickname || '',
+        });
     },
 }));
 


### PR DESCRIPTION
## 📝 관련 이슈
- #38

## 💡 변경 사항
### 핵심 수정 내용
- `KakaoLoginButton` 컴포넌트 신규 추가
- `KakaoCallback` 페이지 신규 추가 및 `/oauth/kakao` 라우트 등록
- `LoginPage` / `SignUpPage`에 카카오 로그인 버튼 노출
- `authStore`에 `userEmail` / `userNickname` 저장 및 `setUserInfo` 액션 추가
- `MyPage`: authStore 값을 fallback으로 사용해 로딩 전 깜빡임 개선
- `PetPage`: 나이/몸무게 음수 입력 유효성 검사 추가

## 🧪 테스트 결과
- [x] 카카오 로그인 버튼 노출 확인
- [x] 카카오 OAuth 콜백 정상 처리 확인

## 🚩 리뷰 포인트 (선택)

## 📸 스크린샷 (선택)